### PR TITLE
remove import from view_form_edit_number

### DIFF
--- a/mage/src/main/res/layout/view_form_edit_number.xml
+++ b/mage/src/main/res/layout/view_form_edit_number.xml
@@ -4,7 +4,6 @@
 
     <data>
         <import type="mil.nga.giat.mage.form.field.NumberConverter"/>
-        <import type="java.lang.Number"/>
         <variable name="field" type="mil.nga.giat.mage.form.FormField&lt;Number>"/>
     </data>
 


### PR DESCRIPTION
Removing this import fixed the error I was getting:

>mage-android/mage/build/generated/source/kapt/defaultsDebug/mil/nga/giat/mage/DataBinderMapperImpl.java:25: error: cannot find symbol
>import mil.nga.giat.mage.databinding.ViewFormEditNumberBindingImpl;
>                                    ^
>  symbol:   class ViewFormEditNumberBindingImpl
>  location: package mil.nga.giat.mage.databinding
>e: [kapt] An exception occurred: android.databinding.tool.util.LoggedErrorException: Found data binding errors.
>Missing import expression although it is registered
>file:///.../mage-android/mage/src/main/res/layout/view_form_edit_number.xml