### PR TITLE
Mage #1326, Mage #1252, and Mage #1356

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java openjdk-23

--- a/README.md
+++ b/README.md
@@ -124,14 +124,14 @@ file ./mage/build/outputs/apk/mage-android-defaults-debug.apk
 
 With a device connected to your machine, you can install the MAGE app with the following command:
 ```bash
-./gradlew installDefaultsDebug
+./gradlew installDebug
 ```
 
 ### Test
 
 Run the tests on your device:
 ```bash
-./gradlew connectedDefaultsDebugAndroidTest
+./gradlew connectedDebugAndroidTest
 ```
 
 ## Pull Requests

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,5 @@ org.gradle.jvmargs=-Xmx4096m
 
 # Application properties
 VERSION_CODE=1
-android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu May 06 13:38:17 MDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/mage/build.gradle
+++ b/mage/build.gradle
@@ -2,10 +2,10 @@ import org.ajoberstar.grgit.Grgit
 
 plugins {
     id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
+    id 'kotlin-android'
     id 'kotlin-parcelize'
     id 'kotlin-kapt'
-    id 'org.ajoberstar.grgit' version '4.1.0'
+    id 'org.ajoberstar.grgit' version '5.3.0'
     id 'com.google.dagger.hilt.android'
 }
 
@@ -33,7 +33,13 @@ def googleMapsApiReleaseKey = hasProperty('RELEASE_MAPS_API_KEY') ? RELEASE_MAPS
 def googleMapsApiDebugKey = hasProperty('DEBUG_MAPS_API_KEY') ? DEBUG_MAPS_API_KEY : ''
 
 android {
-    compileSdk 34
+    defaultConfig {
+        compileSdk 34
+    }
+
+    buildFeatures{
+        buildConfig = true
+    }
     namespace 'mil.nga.giat.mage'
 
     dataBinding {
@@ -57,6 +63,10 @@ android {
     kotlinOptions {
         jvmTarget = "21"
         freeCompilerArgs = ["-Xcontext-receivers"]
+        freeCompilerArgs += [
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=1.9.25"
+        ]
     }
 
     buildFeatures {
@@ -82,8 +92,8 @@ android {
         applicationId "mil.nga.giat.mage"
         versionName project.version
         versionCode VERSION_CODE as int
-        minSdkVersion 27
-        targetSdkVersion 33
+        minSdkVersion 34
+        targetSdkVersion 34
         multiDexEnabled true
         resValue "string", "serverURLDefaultValue", serverURL
         resValue "string", "recentMapXYZDefaultValue", "263.0,40.0,3"

--- a/mage/build.gradle
+++ b/mage/build.gradle
@@ -92,7 +92,7 @@ android {
         applicationId "mil.nga.giat.mage"
         versionName project.version
         versionCode VERSION_CODE as int
-        minSdkVersion 34
+        minSdkVersion 27
         targetSdkVersion 34
         multiDexEnabled true
         resValue "string", "serverURLDefaultValue", serverURL

--- a/mage/src/main/AndroidManifest.xml
+++ b/mage/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
 
     <uses-feature

--- a/mage/src/main/java/mil/nga/giat/mage/data/repository/user/UserRepository.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/data/repository/user/UserRepository.kt
@@ -14,17 +14,17 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import mil.nga.giat.mage.R
 import mil.nga.giat.mage.data.datasource.permission.RoleLocalDataSource
+import mil.nga.giat.mage.data.datasource.user.UserLocalDataSource
+import mil.nga.giat.mage.database.dao.MageSqliteOpenHelper
+import mil.nga.giat.mage.database.model.event.Event
+import mil.nga.giat.mage.database.model.user.User
 import mil.nga.giat.mage.di.TokenProvider
 import mil.nga.giat.mage.login.AuthenticationStatus
 import mil.nga.giat.mage.login.AuthorizationStatus
 import mil.nga.giat.mage.network.device.DeviceService
 import mil.nga.giat.mage.network.user.UserService
-import mil.nga.giat.mage.sdk.Compatibility.Companion.isCompatibleWith
-import mil.nga.giat.mage.database.model.event.Event
-import mil.nga.giat.mage.database.model.user.User
-import mil.nga.giat.mage.data.datasource.user.UserLocalDataSource
-import mil.nga.giat.mage.database.dao.MageSqliteOpenHelper
 import mil.nga.giat.mage.network.user.UserWithRoleTypeAdapter
+import mil.nga.giat.mage.sdk.Compatibility.Companion.isCompatibleWith
 import mil.nga.giat.mage.sdk.preferences.PreferenceHelper
 import mil.nga.giat.mage.sdk.utils.DeviceUuidFactory
 import mil.nga.giat.mage.sdk.utils.ISO8601DateFormatFactory
@@ -308,6 +308,10 @@ class UserRepository @Inject constructor(
    private suspend fun syncIcon(user: User) {
       val path = "${MediaUtility.getUserIconDirectory(application)}/${user.id}.png"
       val file = File(path)
+      /// At the moment, I can't see any code that regularly updates User.lastModified
+      /// Aside from the fact that we happen to pull users in their entirety every time we
+      /// do something... That should be fixed and then this code will be absolutely correct.
+      /// Until then, this code is achieving the result of not re-pulling an icon.
       if (file.exists() && user.fetchedDate.before(user.lastModified)) {
          file.delete()
          val response = userService.getIcon(user.remoteId)

--- a/mage/src/main/java/mil/nga/giat/mage/data/repository/user/UserRepository.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/data/repository/user/UserRepository.kt
@@ -308,15 +308,16 @@ class UserRepository @Inject constructor(
    private suspend fun syncIcon(user: User) {
       val path = "${MediaUtility.getUserIconDirectory(application)}/${user.id}.png"
       val file = File(path)
-      if (file.exists()) {
+      if (file.exists() && user.fetchedDate.before(user.lastModified)) {
          file.delete()
-      }
-
-      val response = userService.getIcon(user.remoteId)
-      val body = response.body()
-      if (response.isSuccessful && body != null) {
-         saveIcon(body, file)
-         compressIcon(file)
+         val response = userService.getIcon(user.remoteId)
+         val body = response.body()
+         if (response.isSuccessful && body != null) {
+            saveIcon(body, file)
+            compressIcon(file)
+            userLocalDataSource.setIconPath(user, path)
+         }
+      } else {
          userLocalDataSource.setIconPath(user, path)
       }
    }

--- a/mage/src/main/java/mil/nga/giat/mage/login/ServerUrlViewModel.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/login/ServerUrlViewModel.kt
@@ -66,6 +66,14 @@ class ServerUrlViewModel @Inject constructor(
       if (Patterns.WEB_URL.matcher(url).matches()) {
          _urlState.value = UrlState.InProgress
 
+         var processedUrl:String = url
+         if (!processedUrl.contains("://")) {
+            processedUrl = "https://" + url
+         }
+         if (processedUrl.endsWith("/")) {
+            processedUrl = processedUrl.dropLast(1)
+         }
+
          viewModelScope.launch(Dispatchers.IO) {
             when (val response = apiRepository.getApi(url)) {
                is ApiResponse.Success -> {

--- a/mage/src/main/java/mil/nga/giat/mage/login/ServerUrlViewModel.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/login/ServerUrlViewModel.kt
@@ -75,13 +75,13 @@ class ServerUrlViewModel @Inject constructor(
          }
 
          viewModelScope.launch(Dispatchers.IO) {
-            when (val response = apiRepository.getApi(url)) {
+            when (val response = apiRepository.getApi(processedUrl)) {
                is ApiResponse.Success -> {
                   daoStore.resetDatabase()
                   database.destroy()
                   preferences
                      .edit()
-                     .putString(application.getString(R.string.serverURLKey), url)
+                     .putString(application.getString(R.string.serverURLKey), processedUrl)
                      .apply()
 
                   _urlState.postValue(UrlState.Valid)

--- a/mage/tests/AndroidManifest.xml
+++ b/mage/tests/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.SET_ANIMATION_SCALE"/>
 
     <uses-sdk
-        android:minSdkVersion="34"
+        android:minSdkVersion="16"
         android:targetSdkVersion="34" />
 
     <instrumentation

--- a/mage/tests/AndroidManifest.xml
+++ b/mage/tests/AndroidManifest.xml
@@ -7,8 +7,8 @@
     <uses-permission android:name="android.permission.SET_ANIMATION_SCALE"/>
 
     <uses-sdk
-        android:minSdkVersion="16"
-        android:targetSdkVersion="19" />
+        android:minSdkVersion="34"
+        android:targetSdkVersion="34" />
 
     <instrumentation
         android:label="AndroidJUnitRunner"

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,10 @@ pluginManagement {
     }
 }
 
+plugins {
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.8.0'
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {


### PR DESCRIPTION
Typically I would not stack so many issues into a single branch, but this is a special occasion due to the newness of our procedures. 

MAGE #1326 Testing Procedures:

This is essentially an android upgrade, I also believe that due to the newly required granularity of location settings that MAGE #977 is also solved by this. 

Due to the broad nature of this change, running through the other test procedures should prove this. 

MAGE #1356 Testing Procedures:

As it stands, before this update if you attempt to use a MAGE server URL with a slash at the end it will fail and tell you that the URL is invalid. This is silly, and the code for this change was already there, it just needed to actually be implemented. 

- Run MAGE Application on your Android Device
- On Server Entry use the value "https://magedev.geointnext.com/"
- Log in as normal

Assuming you were able to successfully log in, then the issue is successful as it no longer fails with the trailing slash. 

MAGE #1252 Testing Procedures

Harder to test, as it is difficult to see from the front end if something is loading multiple times, so a bit of extra scrutiny on the code for this one.  That Said, an event should still be done for proper testing coverage. 

- Run MAGE Application
- Log In To Device
- Select an Event to View from the list
    - If there are no events, you will need to go make one on the server that you have chosen, also make sure there are multiple users in the event. 
- Load the Event
- Make an Observation and let it sync to the server
- For extra clarity you could also run a second event, but this is probably a bit over zealous testing.

The only note is that this may load slightly faster, although not anything that can be noticed at our small sample size. This issue can only truly be noticed, and the benefits seen from.
