### PR TITLE
Feature/#1391: Contact Us button

### DIFF
--- a/mage/src/main/java/mil/nga/giat/mage/LandingActivity.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/LandingActivity.kt
@@ -3,6 +3,7 @@ package mil.nga.giat.mage
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.res.Configuration
+import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
@@ -25,9 +26,9 @@ import kotlinx.coroutines.launch
 import mil.nga.geopackage.validate.GeoPackageValidate
 import mil.nga.giat.mage.LandingViewModel.NavigationTab
 import mil.nga.giat.mage.cache.GeoPackageCacheUtils
+import mil.nga.giat.mage.data.datasource.event.EventLocalDataSource
 import mil.nga.giat.mage.data.datasource.user.UserLocalDataSource
 import mil.nga.giat.mage.database.model.event.Event
-import mil.nga.giat.mage.data.datasource.event.EventLocalDataSource
 import mil.nga.giat.mage.database.model.feed.Feed
 import mil.nga.giat.mage.databinding.ActivityLandingBinding
 import mil.nga.giat.mage.event.EventActivity
@@ -52,6 +53,7 @@ import mil.nga.giat.mage.profile.ProfileActivity
 import org.apache.commons.lang3.StringUtils
 import java.io.File
 import javax.inject.Inject
+
 
 /**
  * This is the Activity that holds other fragments. Map, feeds, etc. It
@@ -316,6 +318,12 @@ class LandingActivity : AppCompatActivity(), NavigationView.OnNavigationItemSele
             startActivity(intent)
          }
 
+         R.id.email_navigation -> {
+            val intent = Intent(Intent.ACTION_SENDTO)
+            intent.setData(Uri.parse("mailto:$CONTACT_EMAIL"))
+            startActivity(intent)
+         }
+
          R.id.logout_navigation -> {
             application.onLogout(true)
             val intent = Intent(applicationContext, LoginActivity::class.java)
@@ -410,5 +418,8 @@ class LandingActivity : AppCompatActivity(), NavigationView.OnNavigationItemSele
       private const val CHANGE_EVENT_REQUEST = 200
 
       const val EXTRA_OPEN_FILE_PATH = "extra_open_file_path"
+
+      // TODO: update our contact email
+      private const val CONTACT_EMAIL: String = "TODO@omnifederal.com"
    }
 }

--- a/mage/src/main/java/mil/nga/giat/mage/LandingActivity.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/LandingActivity.kt
@@ -419,7 +419,7 @@ class LandingActivity : AppCompatActivity(), NavigationView.OnNavigationItemSele
 
       const val EXTRA_OPEN_FILE_PATH = "extra_open_file_path"
 
-      // TODO: update our contact email
-      private const val CONTACT_EMAIL: String = "TODO@omnifederal.com"
+      private const val CONTACT_EMAIL: String = "magesuitesupport@nga.mil"
+      private const val CONTACT_PHONE: String = "tel:5715571121"
    }
 }

--- a/mage/src/main/res/menu/top_navigation_items.xml
+++ b/mage/src/main/res/menu/top_navigation_items.xml
@@ -45,6 +45,11 @@
             android:title="@string/About" />
 
         <item
+            android:id="@+id/email_navigation"
+            android:icon="@drawable/ic_email_white_24dp"
+            android:title="@string/contact_us" />
+
+        <item
             android:id="@+id/logout_navigation"
             android:icon="@drawable/ic_power_settings_new_white_24dp"
             android:title="@string/Logout" />

--- a/mage/src/main/res/values/strings.xml
+++ b/mage/src/main/res/values/strings.xml
@@ -289,4 +289,5 @@
     <string name="or">or</string>
     <string name="wand_description">A Magic Wand With Sparkles</string>
     <string name="sign_in_google">Sign in with Google</string>
+    <string name="contact_us">Contact Us</string>
 </resources>


### PR DESCRIPTION
# Feature/1391-contact-us-button

## Gitlab: https://gitlab.dso.xc.nga.mil/Mobile-Awareness-GEOINT-Environment/mage/mage/-/issues/1391
- added *Contact Us* button in main menu settings under *About* button
  + <img width="200" alt="contact_us_button" src="https://github.com/user-attachments/assets/6896991a-b361-4b7f-8b53-31cb20266062" />

- when you click the button you're presented with the standard Android email setup process if you haven't already setup an email account.
  + <img width="200" alt="contact_us_step_1" src="https://github.com/user-attachments/assets/0bb2294f-f8b3-498b-92f2-505334584a56" /> <img width="200" alt="contact_us_step_2" src="https://github.com/user-attachments/assets/a3390616-dc6a-483c-86de-98a7a7872900" /> <img width="200" alt="contact_us_step_3" src="https://github.com/user-attachments/assets/919b33d4-d4c0-446e-8e2b-247ea152380f" />

- Once you've setup an email account it finally presents the email form with the *to:* portion auto-populated with our **CONTACT_EMAIL** string.
  + <img width="200" alt="contact_us_step_final" src="https://github.com/user-attachments/assets/698a7c7a-64bf-4aca-a909-69d616537b78" />
