### PR TITLE
[mage-1748]

### DIFF
--- a/mage/src/main/java/mil/nga/giat/mage/data/datasource/observation/ObservationLocalDataSource.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/data/datasource/observation/ObservationLocalDataSource.kt
@@ -264,6 +264,19 @@ class ObservationLocalDataSource @Inject constructor(
    }
 
    @Throws(ObservationException::class)
+   fun updateObservationError(observation: Observation) {
+      try {
+         val updateBuilder = observationDao.updateBuilder()
+         updateBuilder.where().eq("_id", observation.id)
+         updateBuilder.updateColumnValue("error", observation.error)
+         updateBuilder.update()
+      } catch (e: Exception) {
+         Log.e(LOG_NAME, "Failed to update observation error status for observation ${observation.id}", e)
+         throw ObservationException("Failed to update observation error", e)
+      }
+   }
+
+   @Throws(ObservationException::class)
    fun readAll(): List<Observation> {
       return try {
          observationDao.queryForAll()

--- a/mage/src/main/java/mil/nga/giat/mage/data/repository/observation/ObservationRepository.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/data/repository/observation/ObservationRepository.kt
@@ -113,7 +113,7 @@ class ObservationRepository @Inject constructor(
          response = update(observation)
       } else {
          observation.error = parseError(response)
-         observationLocalDataSource.updateObservations(listOf(observation))
+         observationLocalDataSource.updateObservationError(observation)
       }
 
       response
@@ -314,7 +314,7 @@ class ObservationRepository @Inject constructor(
          returnedObservation?.let { observationLocalDataSource.updateObservations(listOf(it)) }
       } else {
          observation.error = parseError(response)
-         observationLocalDataSource.updateObservations(listOf(observation))
+         observationLocalDataSource.updateObservationError(observation)
       }
 
       response
@@ -331,7 +331,7 @@ class ObservationRepository @Inject constructor(
          }
          response.code() != HttpURLConnection.HTTP_UNAUTHORIZED -> {
             observation.error = parseError(response)
-            observationLocalDataSource.updateObservations(listOf(observation))
+            observationLocalDataSource.updateObservationError(observation)
          }
       }
 


### PR DESCRIPTION
Update logic for writing server errors to the observations table, to avoid an infinite retry loop that causes the observations list page to appear to "glitch"