### PR TITLE
Fix user filter logic to correctly use event remoteId instead of id

### DIFF
--- a/mage/src/main/java/mil/nga/giat/mage/data/repository/user/UserRepository.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/data/repository/user/UserRepository.kt
@@ -377,10 +377,10 @@ class UserRepository @Inject constructor(
 
 
 
-   suspend fun getUserSetForEvent(eventId: Long?): Set<UserInfo> {
+   suspend fun getUserSetForEvent(remoteEventId: String?): Set<UserInfo> {
       val uniqueUserSet = TreeSet<UserInfo>(emptySet())
       try {
-         val response = userService.getUsersForEvent(eventId)
+         val response = userService.getUsersForEvent(remoteEventId)
          if (response.isSuccessful) {
             val userInfoList = response.body()
 
@@ -390,7 +390,7 @@ class UserRepository @Inject constructor(
             }
          }
       } catch (e: Exception) {
-         Log.e(LOG_NAME, "Error fetching user list for event: $eventId", e)
+         Log.e(LOG_NAME, "Error fetching user list for event: $remoteEventId", e)
       }
 
       return uniqueUserSet

--- a/mage/src/main/java/mil/nga/giat/mage/network/user/UserService.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/network/user/UserService.kt
@@ -51,5 +51,5 @@ interface UserService {
    suspend fun createAvatar(@PartMap parts: Map<String, RequestBody>): Response<UserWithRole>
 
    @GET("/api/events/{eventId}/users")
-   suspend fun getUsersForEvent(@Path("eventId") eventId: Long?): Response<List<UserInfo>>
+   suspend fun getUsersForEvent(@Path("eventId") remoteEventId: String?): Response<List<UserInfo>>
 }

--- a/mage/src/main/java/mil/nga/giat/mage/ui/filter/UserFilterViewModel.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/ui/filter/UserFilterViewModel.kt
@@ -62,19 +62,17 @@ class UserFilterViewModel @Inject constructor(
             //show loading indicator
             _isLoading.value = true
 
-            val eventId = currentEvent?.id
-
             //attempt to retrieve the event's assigned users from the /api/events/{eventId}/users API
             //if the API returns no users or an error, then fall back to retrieving users from the observations table
-            if (eventId != null) {
-                val userSet = userRepository.getUserSetForEvent(eventId)
+            if (currentEvent != null) {
+                val remoteEventId = currentEvent.remoteId
+                val userSet = userRepository.getUserSetForEvent(remoteEventId)
 
                 if (userSet.isNotEmpty()) {
                     val userInfoList = userSet.toList().sort()
                     _usersForEvent.value = userInfoList
                 } else {
-                    val event = eventLocalDataSource.read(eventId)
-                    val userList = userLocalDataSource.getUsersInEvent(event).toList()
+                    val userList = userLocalDataSource.getUsersInEvent(currentEvent).toList()
                     if (userList.isNotEmpty()) {
                         //transform the User list to a UserInfo list
                         val userInfoList: List<UserInfo> = userFilterMapper.toUserInfoList(userList)

--- a/mage/src/test/java/mil/nga/giat/mage/ui/filter/UserFilterViewModelTest.kt
+++ b/mage/src/test/java/mil/nga/giat/mage/ui/filter/UserFilterViewModelTest.kt
@@ -114,7 +114,7 @@ class UserFilterViewModelTest {
 
         //default to successful retrieval from repo
         val mockServiceResponse: Response<List<UserInfo>> = Response.success(allMappedUserInfoFromRepo)
-        coEvery { mockUserService.getUsersForEvent(currentEvent.id) } returns mockServiceResponse
+        coEvery { mockUserService.getUsersForEvent(currentEvent.remoteId) } returns mockServiceResponse
 
     }
 
@@ -154,7 +154,7 @@ class UserFilterViewModelTest {
             assertTrue(viewModel.selectedUsersForFilter.value.isEmpty())
             assertEquals(allMappedUserInfoFromRepo, actualUsersMatchingSearch)
 
-            coVerify(exactly = 1) { mockUserService.getUsersForEvent(currentEvent.id) }
+            coVerify(exactly = 1) { mockUserService.getUsersForEvent(currentEvent.remoteId) }
 
             verify { mockUserFilterPrefsManager.getUserFilterList() }
         }
@@ -165,14 +165,14 @@ class UserFilterViewModelTest {
 
             //override successful UserService response in setUp() to return empty list instead
             val mockServiceEmptyResponse: Response<List<UserInfo>> = Response.success(emptyList())
-            coEvery { mockUserService.getUsersForEvent(currentEvent.id) } returns mockServiceEmptyResponse
+            coEvery { mockUserService.getUsersForEvent(currentEvent.remoteId) } returns mockServiceEmptyResponse
 
             initializeViewModel()
             advanceUntilIdle()
 
             assertFalse(viewModel.isLoading.value)
             assertEquals(allMappedUserInfoFromLocalDs, viewModel.usersForEvent.value)
-            coVerify { mockEventLocalDataSource.read(currentEvent.id) }
+            coVerify { mockUserService.getUsersForEvent(currentEvent.remoteId) }
             coVerify { mockUserLocalDataSource.getUsersInEvent(currentEvent) }
             coVerify {
                 mockUserFilterMapper.toUserInfoList(allLocalDsUsers)


### PR DESCRIPTION
Fix user filter logic to correctly use event remoteId instead of id