### PR TITLE
[mage-1877]

### DIFF
--- a/mage/src/main/java/mil/nga/giat/mage/data/repository/observation/ObservationRepository.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/data/repository/observation/ObservationRepository.kt
@@ -216,7 +216,7 @@ class ObservationRepository @Inject constructor(
       }
 
       if (date != null) {
-         filter = DateTimeFilter(date, null, "last_modified")
+         filter = DateTimeFilter(date, null, "timestamp")
          refreshTime = date.time
       }
 


### PR DESCRIPTION
Update the map view to filter observations using the original creation date ("timestamp") rather than "last_modified" date, to maintain consistency with the time filtering on the observations tab, as well as the Mage web app and iOS app