### PR TITLE
Android undo/redo & Material3/Compose updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,9 @@
 plugins {
-    id 'com.android.application' version '8.7.2' apply false
-    id 'com.android.library' version '8.7.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.9.25' apply false
-    id 'com.google.dagger.hilt.android' version '2.51' apply false
+    id 'com.android.application' version '9.2.1' apply false
+    id 'com.android.library' version '9.2.1' apply false
+    id 'org.jetbrains.kotlin.android' version '2.2.10' apply false
+    id 'com.google.dagger.hilt.android' version '2.56' apply false
+    id 'org.jetbrains.kotlin.plugin.compose' version '2.2.10' apply false
 }
 
 tasks.register('clean', Delete) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,14 @@ org.gradle.jvmargs=-Xmx4096m
 # Application properties
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false
+DEBUG_MAPS_API_KEY=AIzaSyAAFhmzxYOgltoCQKXAd93XZPxc5zRqfT8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu May 06 13:38:17 MDT 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-all.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/mage/build.gradle
+++ b/mage/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'kotlin-kapt'
     id 'org.ajoberstar.grgit' version '5.3.0'
     id 'com.google.dagger.hilt.android'
+    id 'org.jetbrains.kotlin.plugin.compose'
 }
 
 group 'mil.nga.giat.mage'
@@ -58,10 +59,6 @@ android {
     kotlinOptions {
         jvmTarget = "17"
         freeCompilerArgs = ["-Xcontext-receivers"]
-        freeCompilerArgs += [
-                "-P",
-                "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=1.9.25"
-        ]
     }
 
     buildFeatures {
@@ -69,9 +66,6 @@ android {
         viewBinding true
     }
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.15"
-    }
 
     packagingOptions {
         resources {
@@ -151,8 +145,8 @@ android {
 
 dependencies {
     ext {
-        lifecycle_version= '2.7.0'
-        room_version = '2.6.1'
+        lifecycle_version= '2.8.7'
+        room_version = '2.7.1'
     }
 
     implementation "androidx.core:core-ktx:1.12.0"
@@ -171,9 +165,9 @@ dependencies {
 
     implementation 'androidx.browser:browser:1.8.0'
 
-    implementation "com.google.dagger:hilt-android:2.51"
+    implementation "com.google.dagger:hilt-android:2.56"
     implementation 'androidx.hilt:hilt-navigation-compose:1.2.0'
-    kapt "com.google.dagger:hilt-compiler:2.51"
+    kapt "com.google.dagger:hilt-compiler:2.56"
     implementation 'androidx.hilt:hilt-work:1.2.0'
     kapt 'androidx.hilt:hilt-compiler:1.2.0'
     annotationProcessor 'androidx.hilt:hilt-compiler:1.2.0'
@@ -181,23 +175,23 @@ dependencies {
     implementation 'com.google.android.material:material:1.11.0'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
 
-    implementation 'androidx.compose.ui:ui:1.6.4'
-    implementation 'androidx.compose.ui:ui-tooling:1.6.4'
-    implementation 'androidx.compose.foundation:foundation:1.6.4'
-    implementation 'androidx.compose.runtime:runtime-livedata:1.6.4'
-    implementation 'androidx.compose.runtime:runtime-rxjava2:1.6.4'
-    implementation "androidx.compose.material3:material3:1.2.1"
-    implementation 'androidx.compose.material:material:1.6.4'
-    implementation 'androidx.compose.material:material-icons-core:1.6.4'
-    implementation 'androidx.compose.material:material-icons-extended:1.6.4'
-    implementation 'androidx.activity:activity-compose:1.8.2'
+    implementation 'androidx.compose.ui:ui:1.8.0'
+    implementation 'androidx.compose.ui:ui-tooling:1.8.0'
+    implementation 'androidx.compose.foundation:foundation:1.8.0'
+    implementation 'androidx.compose.runtime:runtime-livedata:1.8.0'
+    implementation 'androidx.compose.runtime:runtime-rxjava2:1.8.0'
+    implementation "androidx.compose.material3:material3:1.4.0"
+    implementation 'androidx.compose.material:material:1.8.0'
+    implementation 'androidx.compose.material:material-icons-core:1.7.8'
+    implementation 'androidx.compose.material:material-icons-extended:1.7.8'
+    implementation 'androidx.activity:activity-compose:1.10.0'
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
     implementation "com.google.accompanist:accompanist-swiperefresh:0.19.0"
 
-    implementation('androidx.paging:paging-runtime-ktx:3.2.1')
-    implementation("androidx.paging:paging-compose:3.2.1")
+    implementation('androidx.paging:paging-runtime-ktx:3.4.0')
+    implementation("androidx.paging:paging-compose:3.4.0")
 
     implementation ('androidx.work:work-runtime-ktx:2.9.0')
 

--- a/mage/build.gradle
+++ b/mage/build.gradle
@@ -160,8 +160,8 @@ dependencies {
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.preference:preference-ktx:1.2.1'
     implementation 'androidx.preference:preference-ktx:1.2.1'
-    implementation "com.google.android.gms:play-services-maps:18.2.0"
-    implementation 'com.google.maps.android:maps-ktx:3.4.0'
+    implementation 'com.google.android.gms:play-services-maps:19.0.0'
+    implementation 'com.google.maps.android:maps-ktx:5.1.1'
 
     implementation 'androidx.browser:browser:1.8.0'
 
@@ -179,7 +179,6 @@ dependencies {
     implementation 'androidx.compose.ui:ui-tooling:1.8.0'
     implementation 'androidx.compose.foundation:foundation:1.8.0'
     implementation 'androidx.compose.runtime:runtime-livedata:1.8.0'
-    implementation 'androidx.compose.runtime:runtime-rxjava2:1.8.0'
     implementation "androidx.compose.material3:material3:1.4.0"
     implementation 'androidx.compose.material:material:1.8.0'
     implementation 'androidx.compose.material:material-icons-core:1.7.8'
@@ -206,9 +205,7 @@ dependencies {
     implementation "androidx.room:room-ktx:$room_version"
     implementation 'com.j256.ormlite:ormlite-android:6.1'
 
-    implementation 'com.google.maps.android:maps-compose:2.11.4'
-    implementation 'com.google.maps.android:maps-compose-utils:2.11.4'
-    implementation 'com.google.maps.android:maps-compose-widgets:2.11.4'
+    implementation 'com.google.maps.android:maps-compose:6.4.1'
 
     implementation 'com.google.maps.android:android-maps-utils:3.5.3'
     implementation 'mil.nga.geopackage.map:geopackage-android-map:6.7.5'

--- a/mage/build.gradle
+++ b/mage/build.gradle
@@ -145,18 +145,18 @@ android {
 
 dependencies {
     ext {
-        lifecycle_version= '2.8.7'
+        lifecycle_version= '2.9.1'
         room_version = '2.7.1'
     }
 
-    implementation "androidx.core:core-ktx:1.12.0"
-    implementation "androidx.fragment:fragment-ktx:1.6.2"
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation "androidx.core:core-ktx:1.16.0"
+    implementation "androidx.fragment:fragment-ktx:1.8.8"
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
     implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
     implementation 'androidx.mediarouter:mediarouter:1.7.0'
-    implementation 'androidx.recyclerview:recyclerview:1.3.2'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.recyclerview:recyclerview:1.4.0'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.preference:preference-ktx:1.2.1'
     implementation 'androidx.preference:preference-ktx:1.2.1'
@@ -172,7 +172,7 @@ dependencies {
     kapt 'androidx.hilt:hilt-compiler:1.2.0'
     annotationProcessor 'androidx.hilt:hilt-compiler:1.2.0'
 
-    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'com.google.android.material:material:1.12.0'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
 
     implementation 'androidx.compose.ui:ui:1.8.0'
@@ -188,18 +188,17 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-compose:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
-    implementation "com.google.accompanist:accompanist-swiperefresh:0.19.0"
 
     implementation('androidx.paging:paging-runtime-ktx:3.4.0')
     implementation("androidx.paging:paging-compose:3.4.0")
 
-    implementation ('androidx.work:work-runtime-ktx:2.9.0')
+    implementation ('androidx.work:work-runtime-ktx:2.10.1')
 
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     implementation 'com.squareup.retrofit2:converter-jackson:2.9.0'
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
-    implementation 'com.squareup.okhttp3:okhttp-urlconnection:3.11.0'
+    implementation 'com.squareup.okhttp3:okhttp-urlconnection:4.12.0'
 
     implementation "androidx.room:room-runtime:$room_version"
     implementation "androidx.room:room-paging:$room_version"
@@ -218,22 +217,22 @@ dependencies {
     implementation 'org.ocpsoft.prettytime:prettytime:3.2.5.Final'
     implementation 'com.mapbox.mapboxsdk:mapbox-sdk-geojson:4.6.0'
 
-    implementation 'com.github.bumptech.glide:glide:4.13.2'
-    implementation 'com.github.bumptech.glide:okhttp3-integration:4.13.2'
-    implementation "com.google.accompanist:accompanist-glide:0.15.0"
+    implementation 'com.github.bumptech.glide:glide:4.16.0'
+    implementation 'com.github.bumptech.glide:okhttp3-integration:4.16.0'
     implementation "com.github.bumptech.glide:compose:1.0.0-beta01"
-    kapt 'com.github.bumptech.glide:compiler:4.13.2'
+    kapt 'com.github.bumptech.glide:compiler:4.16.0'
 
     implementation 'com.nulab-inc:zxcvbn:1.2.3'
 
     implementation 'androidx.exifinterface:exifinterface:1.3.7'
-    implementation "com.google.android.exoplayer:exoplayer:2.19.1"
+    implementation 'androidx.media3:media3-exoplayer:1.4.1'
+    implementation 'androidx.media3:media3-ui:1.4.1'
 
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'com.google.android.gms:play-services-location:21.2.0'
 
     implementation 'com.google.guava:guava:31.0-android'
-    implementation 'org.apache.commons:commons-lang3:3.3.2'
+    implementation 'org.apache.commons:commons-lang3:3.17.0'
 
     implementation files ('libs/sanselanandroid.jar')
 

--- a/mage/src/main/java/mil/nga/giat/mage/data/datasource/observation/ObservationLocalDataSource.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/data/datasource/observation/ObservationLocalDataSource.kt
@@ -46,6 +46,7 @@ class ObservationLocalDataSource @Inject constructor(
             try {
                createObservation(observation)
             } catch (e: ObservationException) {
+               Log.e(LOG_NAME, "Failed to create observation: $observation", e)
                createdObservations.remove(observation)
             }
          }
@@ -131,6 +132,7 @@ class ObservationLocalDataSource @Inject constructor(
                val updatedObservation = updateObservation(observation)
                updatedObservations.add(updatedObservation)
             } catch (e: ObservationException) {
+               Log.e(LOG_NAME, "Failed to update observation: $observation", e)
             }
          }
       }
@@ -387,6 +389,7 @@ class ObservationLocalDataSource @Inject constructor(
             try {
                deleteObservation(observation)
             } catch (e: ObservationException) {
+               Log.e(LOG_NAME, "Failed to delete observation: $observation", e)
             }
          }
       }
@@ -506,11 +509,6 @@ class ObservationLocalDataSource @Inject constructor(
     */
    @Throws(ObservationException::class)
    fun removeImportant(observation: Observation) {
-      try {
-         observationImportantDao.queryForAll()
-      } catch (e: SQLException) {
-         Log.e(LOG_NAME, "Error querying for observations", e)
-      }
       val important = observation.important
       if (important != null) {
          important.isImportant = false

--- a/mage/src/main/java/mil/nga/giat/mage/data/repository/feed/FeedRepository.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/data/repository/feed/FeedRepository.kt
@@ -1,5 +1,6 @@
 package mil.nga.giat.mage.data.repository.feed
 
+import android.util.Log
 import androidx.annotation.WorkerThread
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -24,20 +25,29 @@ class FeedRepository @Inject constructor(
    private val feedService: FeedService,
    private val eventLocalDataSource: EventLocalDataSource
 ) {
+   companion object {
+      private const val LOG_TAG = "FeedRepository"
+   }
+
    suspend fun syncFeed(feed: Feed) = withContext(Dispatchers.IO) {
       val resource = try {
          eventLocalDataSource.currentEvent?.let { event ->
             val response = feedService.getFeedItems(event.remoteId, feed.id)
+            Log.d(LOG_TAG, "Feed ${feed.title} sync response: ${response.code()} successful=${response.isSuccessful}")
             if (response.isSuccessful) {
-               response.body()?.let { content ->
-                  saveFeed(feed, content)
-                  Resource.success(content)
+               val content = response.body()
+               Log.d(LOG_TAG, "Feed ${feed.title} body parsed: ${content != null}, items=${content?.items?.size ?: "null"}")
+               content?.let {
+                  saveFeed(feed, it)
+                  Resource.success(it)
                } ?: Resource.error("Error parsing feed content body", null)
             } else {
+               Log.e(LOG_TAG, "Feed ${feed.title} sync failed: ${response.code()} ${response.message()}")
                Resource.error(response.message(), null)
             }
          }
       } catch (e: Exception) {
+         Log.e(LOG_TAG, "Feed ${feed.title} sync exception", e)
          Resource.error(e.localizedMessage ?: e.toString(), null)
       }
 

--- a/mage/src/main/java/mil/nga/giat/mage/feed/FeedScreen.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/feed/FeedScreen.kt
@@ -1,6 +1,5 @@
 package mil.nga.giat.mage.feed
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -27,10 +26,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
-import com.google.accompanist.glide.rememberGlidePainter
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.SwipeRefreshIndicator
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
 import com.google.android.gms.maps.model.LatLng
 import mil.nga.giat.mage.R
 import mil.nga.giat.mage.coordinate.CoordinateFormatter
@@ -79,16 +78,10 @@ fun FeedScreen(
             )
          },
          content = { paddingValues ->
-            SwipeRefresh(
-               state = rememberSwipeRefreshState(isRefreshing),
+            @OptIn(ExperimentalMaterial3Api::class)
+            PullToRefreshBox(
+               isRefreshing = isRefreshing,
                onRefresh = { viewModel.refresh() },
-               indicator = { state, trigger ->
-                  SwipeRefreshIndicator(
-                     state = state,
-                     refreshTriggerDistance = trigger,
-                     contentColor = MaterialTheme.colors.primary,
-                  )
-               },
                modifier = Modifier.padding(paddingValues)
             ) {
                feedItems?.collectAsLazyPagingItems()?.let { items ->
@@ -347,16 +340,11 @@ fun FeedItemIcon(
    modifier: Modifier = Modifier,
 ) {
    Box(modifier = modifier) {
-      Image(
-         painter = rememberGlidePainter(
-            itemState.iconUrl,
-            fadeIn = true,
-            requestBuilder = {
-               error(R.drawable.default_marker)
-            }
-         ),
+      @OptIn(ExperimentalGlideComposeApi::class)
+      GlideImage(
+         model = itemState.iconUrl,
          contentDescription = "Feed Item Icon",
-         Modifier.fillMaxSize()
-      )
+         modifier = Modifier.fillMaxSize(),
+      ) { it.error(R.drawable.default_marker) }
    }
 }

--- a/mage/src/main/java/mil/nga/giat/mage/form/defaults/FormDefaultViewModel.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/form/defaults/FormDefaultViewModel.kt
@@ -4,7 +4,11 @@ import android.app.Application
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import mil.nga.giat.mage.form.Form
 import mil.nga.giat.mage.form.FormField
 import mil.nga.giat.mage.form.FormState
@@ -30,16 +34,20 @@ class FormDefaultViewModel @Inject constructor(
   fun setForm(eventId: Long, formId: Long) {
     formPreferences = FormPreferences(application, eventId, formId)
 
-    // TODO get this in background coroutine
-    try {
-      val event = eventLocalDataSource.read(eventId)
-      formJson = eventLocalDataSource.getForm(formId)?.json
-      Form.fromJson(formJson)?.let { form ->
-        val defaultForm = FormPreferences(application, event.id, form.id).getDefaults()
-        _formState.value = FormState.fromForm(eventId = event.remoteId, form = form, defaultForm = defaultForm)
-      }
-
-    } catch (_: EventException) { }
+    viewModelScope.launch {
+      try {
+        val (event, json) = withContext(Dispatchers.IO) {
+          val event = eventLocalDataSource.read(eventId)
+          val json = eventLocalDataSource.getForm(formId)?.json
+          event to json
+        }
+        formJson = json
+        Form.fromJson(formJson)?.let { form ->
+          val defaultForm = FormPreferences(application, event.id, form.id).getDefaults()
+          _formState.value = FormState.fromForm(eventId = event.remoteId, form = form, defaultForm = defaultForm)
+        }
+      } catch (_: EventException) { }
+    }
   }
 
   fun saveDefaults() {

--- a/mage/src/main/java/mil/nga/giat/mage/form/edit/FormEdit.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/form/edit/FormEdit.kt
@@ -27,8 +27,10 @@ import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.sp
 import mil.nga.giat.mage.database.model.event.Event
@@ -437,6 +439,12 @@ fun TextEdit(
   val lastHistoryText = remember { object { var value = fieldState.answer?.text ?: "" } }
   val isFirstChange = remember { object { var value = true } }
 
+  var textFieldValue by remember { mutableStateOf(TextFieldValue(text = fieldState.answer?.text ?: "")) }
+  val currentAnswerText = fieldState.answer?.text ?: ""
+  if (currentAnswerText != textFieldValue.text) {
+    textFieldValue = TextFieldValue(text = currentAnswerText, selection = TextRange(currentAnswerText.length))
+  }
+
   val keyboardType = if (fieldState.definition.type == FieldType.EMAIL) {
     KeyboardType.Email
   } else {
@@ -445,14 +453,17 @@ fun TextEdit(
 
   Column(modifier) {
     TextField(
-      value = fieldState.answer?.text ?: "",
-      onValueChange = { newText ->
+      value = textFieldValue,
+      onValueChange = { newValue ->
+        textFieldValue = newValue
+        val newText = newValue.text
         val capturedPrev = lastHistoryText.value
         onAnswer(newText)
         if (fieldState is TextFieldState) {
           pendingJob.value?.cancel()
           if (isFirstChange.value) {
             isFirstChange.value = false
+            fieldState.isTypingActive = true
             fieldState.pushHistory(capturedPrev)
             lastHistoryText.value = newText
           } else {
@@ -478,6 +489,7 @@ fun TextEdit(
           if (focused && fieldState is TextFieldState) {
             isFirstChange.value = true
             lastHistoryText.value = fieldState.answer?.text ?: ""
+            fieldState.isTypingActive = false
           }
           if (!focused && fieldState is TextFieldState) {
             pendingJob.value?.cancel()
@@ -545,16 +557,25 @@ fun NumberEdit(
   val lastHistoryText = remember { object { var value = fieldState.answer?.number ?: "" } }
   val isFirstChange = remember { object { var value = true } }
 
+  var textFieldValue by remember { mutableStateOf(TextFieldValue(text = fieldState.answer?.number ?: "")) }
+  val currentAnswerNumber = fieldState.answer?.number ?: ""
+  if (currentAnswerNumber != textFieldValue.text) {
+    textFieldValue = TextFieldValue(text = currentAnswerNumber, selection = TextRange(currentAnswerNumber.length))
+  }
+
   Column(modifier) {
     TextField(
-      value = fieldState.answer?.number ?: "",
-      onValueChange = { newText ->
+      value = textFieldValue,
+      onValueChange = { newValue ->
+        textFieldValue = newValue
+        val newText = newValue.text
         val capturedPrev = lastHistoryText.value
         onAnswer(newText)
         if (fieldState is NumberFieldState) {
           pendingJob.value?.cancel()
           if (isFirstChange.value) {
             isFirstChange.value = false
+            fieldState.isTypingActive = true
             fieldState.pushHistory(capturedPrev)
             lastHistoryText.value = newText
           } else {
@@ -584,6 +605,7 @@ fun NumberEdit(
           if (focused && fieldState is NumberFieldState) {
             isFirstChange.value = true
             lastHistoryText.value = fieldState.answer?.number ?: ""
+            fieldState.isTypingActive = false
           }
           if (!focused && fieldState is NumberFieldState) {
             pendingJob.value?.cancel()

--- a/mage/src/main/java/mil/nga/giat/mage/form/edit/FormEdit.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/form/edit/FormEdit.kt
@@ -8,6 +8,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.*
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
@@ -153,15 +156,13 @@ fun FieldEditContent(
         onClick)
     }
     FieldType.NUMBERFIELD -> {
-      NumberEdit(
-        modifier,
-        fieldState as NumberFieldState
-      ) {
-        fieldState.answer = FieldValue.Number(it)
+      val state = fieldState as NumberFieldState
+      NumberEdit(modifier, state) { newText ->
+        state.answer = FieldValue.Number(newText)
       }
     }
     FieldType.PASSWORD -> {
-      TextEdit(
+      PasswordEdit(
         modifier,
         fieldState as TextFieldState,
         icon = {
@@ -183,31 +184,33 @@ fun FieldEditContent(
       }
     }
     FieldType.TEXTFIELD -> {
+      val state = fieldState as TextFieldState
       TextEdit(
         modifier,
-        fieldState as TextFieldState,
+        state,
         icon = {
           Icon(
             imageVector = Icons.Outlined.Title,
             contentDescription = "Text",
           )
         }
-      ) {
-        fieldState.answer = FieldValue.Text(it)
+      ) { newText ->
+        state.answer = FieldValue.Text(newText)
       }
     }
     FieldType.TEXTAREA -> {
+      val state = fieldState as TextFieldState
       TextEdit(
         modifier,
-        fieldState as TextFieldState,
+        state,
         icon = {
           Icon(
             imageVector = Icons.Outlined.TextFields,
             contentDescription = "Text",
           )
         }
-      ) {
-        fieldState.answer = FieldValue.Text(it)
+      ) { newText ->
+        state.answer = FieldValue.Text(newText)
       }
     }
   }
@@ -429,6 +432,10 @@ fun TextEdit(
   onAnswer: (String) -> Unit,
 ) {
   val focusManager = LocalFocusManager.current
+  val scope = rememberCoroutineScope()
+  val pendingJob = remember { object { var value: Job? = null } }
+  val lastHistoryText = remember { object { var value = fieldState.answer?.text ?: "" } }
+  val isFirstChange = remember { object { var value = true } }
 
   val keyboardType = if (fieldState.definition.type == FieldType.EMAIL) {
     KeyboardType.Email
@@ -439,13 +446,77 @@ fun TextEdit(
   Column(modifier) {
     TextField(
       value = fieldState.answer?.text ?: "",
-      onValueChange = onAnswer,
+      onValueChange = { newText ->
+        val capturedPrev = lastHistoryText.value
+        onAnswer(newText)
+        if (fieldState is TextFieldState) {
+          pendingJob.value?.cancel()
+          if (isFirstChange.value) {
+            isFirstChange.value = false
+            fieldState.pushHistory(capturedPrev)
+            lastHistoryText.value = newText
+          } else {
+            pendingJob.value = scope.launch {
+              delay(1500)
+              fieldState.pushHistory(capturedPrev)
+              lastHistoryText.value = newText
+            }
+          }
+        }
+      },
       label = { Text("${fieldState.definition.title}${if (fieldState.definition.required) " *" else ""}") },
       singleLine = fieldState.definition.type != FieldType.TEXTAREA,
       isError = fieldState.showErrors(),
       keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
       keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
-      visualTransformation = if (fieldState.definition.type == FieldType.PASSWORD) PasswordVisualTransformation() else VisualTransformation.None,
+      visualTransformation = VisualTransformation.None,
+      trailingIcon = icon,
+      modifier = Modifier
+        .fillMaxWidth()
+        .onFocusChanged { focusState ->
+          val focused = focusState.isFocused
+          if (focused && fieldState is TextFieldState) {
+            isFirstChange.value = true
+            lastHistoryText.value = fieldState.answer?.text ?: ""
+          }
+          if (!focused && fieldState is TextFieldState) {
+            pendingJob.value?.cancel()
+            val current = fieldState.answer?.text ?: ""
+            if (current != lastHistoryText.value) {
+              fieldState.pushHistory(lastHistoryText.value)
+              lastHistoryText.value = current
+            }
+          }
+          fieldState.onFocusChange(focused)
+          if (!focused) {
+            fieldState.enableShowErrors()
+          }
+        }
+    )
+
+    fieldState.getError()?.let { error -> TextFieldError(textError = error) }
+  }
+}
+
+@Composable
+fun PasswordEdit(
+  modifier: Modifier = Modifier,
+  fieldState: FieldState<String, out FieldValue.Text>,
+  icon: @Composable (() -> Unit)? = null,
+  onAnswer: (String) -> Unit,
+) {
+  val focusManager = LocalFocusManager.current
+
+  Column(modifier) {
+    TextField(
+      value = fieldState.answer?.text ?: "",
+      onValueChange = onAnswer,
+      label = { Text("${fieldState.definition.title}${if (fieldState.definition.required) " *" else ""}") },
+      singleLine = true,
+      isError = fieldState.showErrors(),
+      keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
+      keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+      visualTransformation = PasswordVisualTransformation(),
       trailingIcon = icon,
       modifier = Modifier
         .fillMaxWidth()
@@ -469,13 +540,34 @@ fun NumberEdit(
   onAnswer: (String) -> Unit,
 ) {
   val focusManager = LocalFocusManager.current
+  val scope = rememberCoroutineScope()
+  val pendingJob = remember { object { var value: Job? = null } }
+  val lastHistoryText = remember { object { var value = fieldState.answer?.number ?: "" } }
+  val isFirstChange = remember { object { var value = true } }
 
   Column(modifier) {
     TextField(
       value = fieldState.answer?.number ?: "",
-      onValueChange = { onAnswer(it) },
+      onValueChange = { newText ->
+        val capturedPrev = lastHistoryText.value
+        onAnswer(newText)
+        if (fieldState is NumberFieldState) {
+          pendingJob.value?.cancel()
+          if (isFirstChange.value) {
+            isFirstChange.value = false
+            fieldState.pushHistory(capturedPrev)
+            lastHistoryText.value = newText
+          } else {
+            pendingJob.value = scope.launch {
+              delay(1500)
+              fieldState.pushHistory(capturedPrev)
+              lastHistoryText.value = newText
+            }
+          }
+        }
+      },
       label = { Text("${fieldState.definition.title}${if (fieldState.definition.required) " *" else ""}") },
-      singleLine = fieldState.definition.type != FieldType.TEXTAREA,
+      singleLine = true,
       isError = fieldState.showErrors(),
       keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
       keyboardActions = KeyboardActions(onDone = { focusManager.clearFocus() }),
@@ -489,6 +581,18 @@ fun NumberEdit(
         .fillMaxWidth()
         .onFocusChanged { focusState ->
           val focused = focusState.isFocused
+          if (focused && fieldState is NumberFieldState) {
+            isFirstChange.value = true
+            lastHistoryText.value = fieldState.answer?.number ?: ""
+          }
+          if (!focused && fieldState is NumberFieldState) {
+            pendingJob.value?.cancel()
+            val current = fieldState.answer?.number ?: ""
+            if (current != lastHistoryText.value) {
+              fieldState.pushHistory(lastHistoryText.value)
+              lastHistoryText.value = current
+            }
+          }
           fieldState.onFocusChange(focused)
           if (!focused) {
             fieldState.enableShowErrors()

--- a/mage/src/main/java/mil/nga/giat/mage/form/field/NumberFieldState.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/form/field/NumberFieldState.kt
@@ -6,7 +6,9 @@ import androidx.compose.runtime.setValue
 import mil.nga.giat.mage.form.FormField
 import mil.nga.giat.mage.form.NumberFormField
 
-// TODO multi-form fix bug not allowing/validating decimal numbers
+// Matches strings that are valid partial decimal input: "-", "1.", "-1.", etc.
+private val PARTIAL_NUMBER_REGEX = Regex("^-?\\d*\\.?\\d*$")
+
 class NumberFieldState(definition: FormField<Number>) :
   FieldState<Number, FieldValue.Number>(
     definition,
@@ -52,34 +54,36 @@ class NumberFieldState(definition: FormField<Number>) :
 }
 
 private fun errorMessage(definition: FormField<Number>, value: FieldValue.Number?): String {
-  return if (value?.number?.isEmpty() == true) {
+  val text = value?.number ?: ""
+  return if (text.isEmpty()) {
     "Please enter a value"
-  } else if (value?.number?.toDoubleOrNull() == null) {
-    "Invalid number"
+  } else if (PARTIAL_NUMBER_REGEX.matches(text) && text.toDoubleOrNull() == null) {
+    // Still typing (e.g. "-" or "1.") — no error yet
+    ""
   } else {
-    val number = value.number.toDouble()
-
+    val number = text.toDoubleOrNull() ?: return "Invalid number"
     val numberDefinition = definition as? NumberFormField
     if (numberDefinition?.min != null && number < numberDefinition.min.toDouble()) {
-      return "Must be greater than or equal to  ${numberDefinition.min}"
+      "Must be greater than or equal to ${numberDefinition.min}"
     } else if (numberDefinition?.max != null && number > numberDefinition.max.toDouble()) {
-      return "Must be less than ${numberDefinition.max}"
+      "Must be less than ${numberDefinition.max}"
     } else "Invalid number"
   }
 }
 
 private fun isValid(definition: FormField<Number>, value: FieldValue.Number?): Boolean {
+  val text = value?.number ?: ""
   return if (!definition.required && !hasValue(value)) {
     true
   } else if (definition.required && !hasValue(value)) {
     false
-  } else if (value?.number?.toDoubleOrNull() == null) {
-    false
+  } else if (PARTIAL_NUMBER_REGEX.matches(text) && text.toDoubleOrNull() == null) {
+    // Partial input ("-", "1.", "-1.") — allow it through while user is still typing
+    true
   } else {
-    val number = value.number.toDouble()
-
+    val number = text.toDoubleOrNull() ?: return false
     val numberDefinition = definition as? NumberFormField
-    return if (numberDefinition?.min != null && number < numberDefinition.min.toDouble()) {
+    if (numberDefinition?.min != null && number < numberDefinition.min.toDouble()) {
       false
     } else !(numberDefinition?.max != null && number > numberDefinition.max.toDouble())
   }

--- a/mage/src/main/java/mil/nga/giat/mage/form/field/NumberFieldState.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/form/field/NumberFieldState.kt
@@ -1,5 +1,8 @@
 package mil.nga.giat.mage.form.field
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import mil.nga.giat.mage.form.FormField
 import mil.nga.giat.mage.form.NumberFormField
 
@@ -10,7 +13,41 @@ class NumberFieldState(definition: FormField<Number>) :
     validator = ::isValid,
     errorFor = ::errorMessage,
     hasValue = ::hasValue
-  )
+  ) {
+
+  private val undoStack = ArrayDeque<String>()
+  private val redoStack = ArrayDeque<String>()
+
+  var canUndo by mutableStateOf(false)
+    private set
+  var canRedo by mutableStateOf(false)
+    private set
+
+  fun pushHistory(previous: String) {
+    undoStack.addLast(previous)
+    redoStack.clear()
+    canUndo = true
+    canRedo = false
+  }
+
+  fun undo() {
+    if (undoStack.isEmpty()) return
+    val previous = undoStack.removeLast()
+    redoStack.addLast(answer?.number ?: "")
+    answer = FieldValue.Number(previous)
+    canUndo = undoStack.isNotEmpty()
+    canRedo = true
+  }
+
+  fun redo() {
+    if (redoStack.isEmpty()) return
+    val next = redoStack.removeLast()
+    undoStack.addLast(answer?.number ?: "")
+    answer = FieldValue.Number(next)
+    canUndo = true
+    canRedo = redoStack.isNotEmpty()
+  }
+}
 
 private fun errorMessage(definition: FormField<Number>, value: FieldValue.Number?): String {
   return if (value?.number?.isEmpty() == true) {

--- a/mage/src/main/java/mil/nga/giat/mage/form/field/NumberFieldState.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/form/field/NumberFieldState.kt
@@ -22,6 +22,8 @@ class NumberFieldState(definition: FormField<Number>) :
     private set
   var canRedo by mutableStateOf(false)
     private set
+    
+  var isTypingActive by mutableStateOf(false)
 
   fun pushHistory(previous: String) {
     undoStack.addLast(previous)

--- a/mage/src/main/java/mil/nga/giat/mage/form/field/TextFieldState.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/form/field/TextFieldState.kt
@@ -21,6 +21,8 @@ class TextFieldState(definition: FormField<String>) :
   var canRedo by mutableStateOf(false)
     private set
 
+  var isTypingActive by mutableStateOf(false)
+
   fun pushHistory(previous: String) {
     undoStack.addLast(previous)
     redoStack.clear()

--- a/mage/src/main/java/mil/nga/giat/mage/form/field/TextFieldState.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/form/field/TextFieldState.kt
@@ -1,5 +1,8 @@
 package mil.nga.giat.mage.form.field
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import mil.nga.giat.mage.form.FormField
 
 class TextFieldState(definition: FormField<String>) :
@@ -8,7 +11,41 @@ class TextFieldState(definition: FormField<String>) :
     validator = ::isValid,
     errorFor = ::errorMessage,
     hasValue = ::hasValue
-  )
+  ) {
+
+  private val undoStack = ArrayDeque<String>()
+  private val redoStack = ArrayDeque<String>()
+
+  var canUndo by mutableStateOf(false)
+    private set
+  var canRedo by mutableStateOf(false)
+    private set
+
+  fun pushHistory(previous: String) {
+    undoStack.addLast(previous)
+    redoStack.clear()
+    canUndo = true
+    canRedo = false
+  }
+
+  fun undo() {
+    if (undoStack.isEmpty()) return
+    val previous = undoStack.removeLast()
+    redoStack.addLast(answer?.text ?: "")
+    answer = FieldValue.Text(previous)
+    canUndo = undoStack.isNotEmpty()
+    canRedo = true
+  }
+
+  fun redo() {
+    if (redoStack.isEmpty()) return
+    val next = redoStack.removeLast()
+    undoStack.addLast(answer?.text ?: "")
+    answer = FieldValue.Text(next)
+    canUndo = true
+    canRedo = redoStack.isNotEmpty()
+  }
+}
 
 private fun errorMessage(definition: FormField<String>, value: FieldValue.Text?): String {
   return "Please enter a value"

--- a/mage/src/main/java/mil/nga/giat/mage/form/view/AttachmentViewContent.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/form/view/AttachmentViewContent.kt
@@ -13,9 +13,10 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
 import com.bumptech.glide.load.resource.bitmap.BitmapTransformation
 import com.bumptech.glide.load.resource.bitmap.CenterCrop
-import com.google.accompanist.glide.rememberGlidePainter
 import mil.nga.giat.mage.glide.transform.VideoOverlayTransformation
 import mil.nga.giat.mage.observation.edit.AttachmentAction
 import mil.nga.giat.mage.database.model.observation.Attachment
@@ -92,17 +93,12 @@ fun AttachmentViewContent(
          .height(200.dp)
          .clip(MaterialTheme.shapes.large)
          .clickable { onAttachmentAction?.invoke(AttachmentAction.VIEW) }) {
-      Image(
-         painter = rememberGlidePainter(
-            attachment,
-            fadeIn = true,
-            requestBuilder = {
-               transforms(*transformations.toTypedArray())
-            }
-         ),
+      @OptIn(ExperimentalGlideComposeApi::class)
+      GlideImage(
+         model = attachment,
          contentDescription = "Attachment Preview",
-         Modifier.fillMaxSize()
-      )
+         modifier = Modifier.fillMaxSize(),
+      ) { it.transform(*transformations.toTypedArray()) }
 
       if (deletable) {
          FloatingActionButton(

--- a/mage/src/main/java/mil/nga/giat/mage/geopackage/media/GeoPackageMediaScreen.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/geopackage/media/GeoPackageMediaScreen.kt
@@ -26,7 +26,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.LiveData
-import com.google.accompanist.glide.rememberGlidePainter
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
 import mil.nga.giat.mage.ui.theme.MageTheme
 import mil.nga.giat.mage.ui.theme.topAppBarBackground
 import java.io.File
@@ -106,13 +107,11 @@ private fun MediaImage(
          .fillMaxWidth()
          .background(Color(0x19000000))
    ) {
-      Image(
-         painter = rememberGlidePainter(
-            File(path),
-            fadeIn = true
-         ),
+      @OptIn(ExperimentalGlideComposeApi::class)
+      GlideImage(
+         model = File(path),
          contentDescription = "GeoPackage Image",
-         Modifier.fillMaxSize()
+         modifier = Modifier.fillMaxSize(),
       )
    }
 }

--- a/mage/src/main/java/mil/nga/giat/mage/map/MapFragment.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/map/MapFragment.kt
@@ -61,7 +61,6 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.snackbar.Snackbar
 import com.google.maps.android.ktx.awaitMap
 import com.google.maps.android.ktx.cameraIdleEvents
-import com.google.maps.android.ktx.cameraMoveStartedEvents
 import com.google.maps.android.ktx.mapClickEvents
 import com.google.maps.android.ktx.mapLongClickEvents
 import com.google.maps.android.ktx.markerClickEvents

--- a/mage/src/main/java/mil/nga/giat/mage/map/annotation/MapAnnotation.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/map/annotation/MapAnnotation.kt
@@ -2,6 +2,9 @@ package mil.nga.giat.mage.map.annotation
 
 import android.content.Context
 import android.graphics.Bitmap
+import android.graphics.Color
+import android.util.DisplayMetrics
+import androidx.core.graphics.ColorUtils
 import com.bumptech.glide.load.Transformation
 import mil.nga.giat.mage.database.model.event.Event
 import mil.nga.giat.mage.database.model.event.Form
@@ -116,14 +119,43 @@ data class MapAnnotation<T>(
          val geometry = item.geometry ?: return null
 
          val iconUri = ObservationIconHelper.getObservationIconUriFromFeed(feed, context)
-         val baseStyle = BaseObservationStyle(iconUri)
+
+         val style: BaseObservationStyle = when (geometry.geometryType) {
+            GeometryType.POLYGON, GeometryType.MULTIPOLYGON,
+            GeometryType.LINESTRING, GeometryType.MULTILINESTRING -> {
+               val styleJson = item.properties?.asJsonObject?.getAsJsonObject("style")
+               android.util.Log.d("MapAnnotation", "Feed item ${item.id} geometry=${geometry.geometryType} properties=${item.properties} styleJson=$styleJson")
+               if (styleJson != null) {
+                  val fillHex   = styleJson.get("fillColor")?.takeIf { !it.isJsonNull }?.asString
+                  val strokeHex = styleJson.get("color")?.takeIf { !it.isJsonNull }?.asString
+                  val fillOpacity   = styleJson.get("fillOpacity")?.takeIf { !it.isJsonNull }?.asFloat ?: 0.3f
+                  val strokeOpacity = styleJson.get("opacity")?.takeIf { !it.isJsonNull }?.asFloat ?: 1.0f
+                  val weight = styleJson.get("weight")?.takeIf { !it.isJsonNull }?.asFloat ?: 2.0f
+                  val density = context.resources.displayMetrics.densityDpi.toFloat() / DisplayMetrics.DENSITY_DEFAULT
+
+                  val fillColor = fillHex
+                     ?.let { runCatching { Color.parseColor(it) }.getOrNull() }
+                     ?.let { ColorUtils.setAlphaComponent(it, (fillOpacity * 255).toInt()) }
+                     ?: 0
+                  val strokeColor = strokeHex
+                     ?.let { runCatching { Color.parseColor(it) }.getOrNull() }
+                     ?.let { ColorUtils.setAlphaComponent(it, (strokeOpacity * 255).toInt()) }
+                     ?: Color.BLACK
+
+                  ShapeObservationStyle(iconUri, weight * density, strokeColor, fillColor)
+               } else {
+                  BaseObservationStyle(iconUri)
+               }
+            }
+            else -> BaseObservationStyle(iconUri)
+         }
 
          return MapAnnotation(
             id = item.id,
             layer = feed.id,
             geometry = geometry,
             timestamp = item.timestamp,
-            style = baseStyle
+            style = style
          )
       }
    }

--- a/mage/src/main/java/mil/nga/giat/mage/map/annotation/ShapeObservationStyle.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/map/annotation/ShapeObservationStyle.kt
@@ -206,23 +206,23 @@ class ShapeObservationStyle: BaseObservationStyle {
         }
 
         private fun getStyleFromJson(json: JsonObject, uri: Uri?, context: Context): ShapeObservationStyle {
-            // Get the style properties
-            val fill = json[FILL_ELEMENT].asString
-            val stroke = json[STROKE_ELEMENT].asString
-            val fillOpacity = json[FILL_OPACITY_ELEMENT].asFloat
-            val strokeOpacity = json[STROKE_OPACITY_ELEMENT].asFloat
-            val strokeWidth = json[STROKE_WIDTH_ELEMENT].asFloat
+            val fill = json[FILL_ELEMENT]?.takeIf { !it.isJsonNull }?.asString
+            val stroke = json[STROKE_ELEMENT]?.takeIf { !it.isJsonNull }?.asString
+            val fillOpacity = json[FILL_OPACITY_ELEMENT]?.takeIf { !it.isJsonNull }?.asFloat ?: 1.0f
+            val strokeOpacity = json[STROKE_OPACITY_ELEMENT]?.takeIf { !it.isJsonNull }?.asFloat ?: 1.0f
+            val strokeWidth = json[STROKE_WIDTH_ELEMENT]?.takeIf { !it.isJsonNull }?.asFloat ?: 2.0f
 
-            // Set the stroke width
             val strokeWithDensity = strokeWidth * (context.resources.displayMetrics.densityDpi / DisplayMetrics.DENSITY_DEFAULT)
 
-            // Create and set the stroke color
-            val strokeColor = Color.parseColor(stroke)
-            val strokeColorWithAlpha = ColorUtils.setAlphaComponent(strokeColor, getAlpha(strokeOpacity))
+            val strokeColorWithAlpha = stroke
+                ?.let { runCatching { Color.parseColor(it) }.getOrNull() }
+                ?.let { ColorUtils.setAlphaComponent(it, getAlpha(strokeOpacity)) }
+                ?: Color.BLACK
 
-            // Create and set the fill color
-            val fillColor = Color.parseColor(fill)
-            val fillColorWithAlpha = ColorUtils.setAlphaComponent(fillColor, getAlpha(fillOpacity))
+            val fillColorWithAlpha = fill
+                ?.let { runCatching { Color.parseColor(it) }.getOrNull() }
+                ?.let { ColorUtils.setAlphaComponent(it, getAlpha(fillOpacity)) }
+                ?: 0
 
             return ShapeObservationStyle(uri, strokeWithDensity, strokeColorWithAlpha, fillColorWithAlpha)
         }

--- a/mage/src/main/java/mil/nga/giat/mage/map/detail/MapFeatureDetails.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/map/detail/MapFeatureDetails.kt
@@ -39,7 +39,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.google.accompanist.glide.rememberGlidePainter
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
 import com.google.android.gms.maps.model.LatLng
 import mil.nga.giat.mage.coordinate.CoordinateFormatter
 import mil.nga.giat.mage.map.FeatureMapState
@@ -255,12 +256,11 @@ private fun FeatureIcon(image: Any) {
       .width(64.dp)
       .height(64.dp)
    ) {
-      Image(
-         painter = rememberGlidePainter(
-            image
-         ),
+      @OptIn(ExperimentalGlideComposeApi::class)
+      GlideImage(
+         model = image,
          contentDescription = "Observation Map Icon",
-         Modifier.fillMaxSize()
+         modifier = Modifier.fillMaxSize(),
       )
    }
 }

--- a/mage/src/main/java/mil/nga/giat/mage/map/download/GeoPackageDownloadManager.java
+++ b/mage/src/main/java/mil/nga/giat/mage/map/download/GeoPackageDownloadManager.java
@@ -7,10 +7,11 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.Cursor;
 import android.net.Uri;
-import android.os.AsyncTask;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 import android.util.Log;
+import android.os.Handler;
+import android.os.Looper;
 
 import androidx.core.content.ContextCompat;
 
@@ -22,6 +23,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Executors;
 
 import javax.inject.Singleton;
 
@@ -104,6 +106,24 @@ public class GeoPackageDownloadManager {
         }
     }
 
+    public int getProgress(Layer layer) {
+        int progress = 0;
+        Long downloadId = layer.getDownloadId();
+        if (downloadId != null) {
+            DownloadManager.Query query = new DownloadManager.Query();
+            query.setFilterById(downloadId);
+            try (Cursor cursor = downloadManager.query(query)) {
+                if (cursor.moveToFirst()) {
+                    int columnIndex = cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR);
+                    if (columnIndex != -1) {
+                        progress = cursor.getInt(columnIndex);
+                    }
+                }
+            }
+        }
+        return progress;
+    }
+
     public boolean isDownloading(Layer layer) {
         int status = -1;
         Long downloadId = layer.getDownloadId();
@@ -146,31 +166,35 @@ public class GeoPackageDownloadManager {
 
     public void reconcileDownloads(Collection<Layer> layers, GeoPackageLoadListener listener) {
         Predicate notDownloadedPredicate = (Predicate<Layer>) layer -> !layer.isLoaded();
-
         List<Layer> notDownloaded = Lists.newArrayList(Iterables.filter(layers, notDownloadedPredicate));
-        new GeoPackageLoaderTask(listener).execute(notDownloaded.toArray(new Layer[notDownloaded.size()]));
-    }
-
-    public int getProgress(Layer layer) {
-        int progress = 0;
-
-        Long downloadId = layer.getDownloadId();
-        if (downloadId != null) {
-            DownloadManager.Query query = new DownloadManager.Query();
-            query.setFilterById(downloadId);
-            try (Cursor cursor = downloadManager.query(query)) {
-
-                if (cursor.moveToFirst()) {
-                    int columnIndex = cursor.getColumnIndex(DownloadManager.COLUMN_BYTES_DOWNLOADED_SO_FAR);
-                    if(columnIndex != -1) {
-                        progress = cursor.getInt(columnIndex);
-                    }
-                }
-            }
-        }
-
-        return progress;
-    }
+        
+        // Run the download check on a background thread — DownloadManager cursor
+        // queries and DB writes must not block the main thread
+        Executors.newSingleThreadExecutor().execute(() -> {
+            List<Layer> layersToDownload = new ArrayList<>();
+            
+            for (Layer layer : notDownloaded) {
+                Long downloadId = layer.getDownloadId();
+                if (downloadId == null) {
+                    layersToDownload.add(layer);
+                } else {
+                    DownloadManager.Query query = new DownloadManager.Query();
+                    query.setFilterById(downloadId);
+                    try (Cursor cursor = downloadManager.query(query)) {
+                        int status = getDownloadStatus(cursor);
+                        if (status == DownloadManager.STATUS_SUCCESSFUL) {
+                            loadGeopackage(downloadId, GeoPackageDownloadManager.this.listener);
+                        } else {
+                            layersToDownload.add(layer);
+                        }   
+                    }   
+                }   
+            }   
+            
+            // Post the result back to the main thread — listener may update UI
+            new Handler(Looper.getMainLooper()).post(() -> listener.onReady(layersToDownload));
+        }); 
+    }  
 
     public String getRelativePath(Layer layer) {
         return String.format("MAGE/geopackages/%s/%s", layer.getRemoteId(), layer.getFileName());
@@ -278,46 +302,6 @@ public class GeoPackageDownloadManager {
                     }
                 }
             }
-        }
-    }
-
-    private class GeoPackageLoaderTask extends AsyncTask<Layer, Void, List<Layer>> {
-
-        private GeoPackageLoadListener listener;
-
-        public GeoPackageLoaderTask(GeoPackageLoadListener listener) {
-            this.listener = listener;
-        }
-
-        @Override
-        protected List<Layer> doInBackground(Layer... layers) {
-            List<Layer> layersToDownload = new ArrayList<>();
-
-            for (Layer layer : layers) {
-                Long downloadId = layer.getDownloadId();
-                if (downloadId == null) {
-                    layersToDownload.add(layer);
-                } else {
-                    DownloadManager.Query ImageDownloadQuery = new DownloadManager.Query();
-                    ImageDownloadQuery.setFilterById(downloadId);
-                    try(Cursor cursor = downloadManager.query(ImageDownloadQuery)) {
-                        int status = getDownloadStatus(cursor);
-
-                        if (status == DownloadManager.STATUS_SUCCESSFUL) {
-                            loadGeopackage(downloadId, GeoPackageDownloadManager.this.listener);
-                        } else {
-                            layersToDownload.add(layer);
-                        }
-                    }
-                }
-            }
-
-            return layersToDownload;
-        }
-
-        @Override
-        protected void onPostExecute(List<Layer> layers) {
-            listener.onReady(layers);
         }
     }
 }

--- a/mage/src/main/java/mil/nga/giat/mage/network/geojson/GeometryTypeAdapterFactory.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/network/geojson/GeometryTypeAdapterFactory.kt
@@ -1,6 +1,7 @@
 package mil.nga.giat.mage.network.geojson
 
 import com.google.gson.Gson
+import com.google.gson.JsonParser
 import com.google.gson.TypeAdapter
 import com.google.gson.TypeAdapterFactory
 import com.google.gson.reflect.TypeToken
@@ -15,26 +16,43 @@ class GeometryTypeAdapterFactory : TypeAdapterFactory {
         val rawType: Class<*> = typeToken.rawType
         return if (mil.nga.sf.Geometry::class.java.isAssignableFrom(rawType)) {
             val factory = GeometryAdapterFactory.create()
-            val typeAdapter = factory.create(gson, TypeToken.get(com.mapbox.geojson.Geometry::class.java))
-            geometryTypeAdapter(typeAdapter) as TypeAdapter<T>
+            val writeAdapter = factory.create(gson, TypeToken.get(com.mapbox.geojson.Geometry::class.java))
+            geometryTypeAdapter(writeAdapter) as TypeAdapter<T>
         } else { null }
     }
 
-    private fun geometryTypeAdapter(typeAdapter: TypeAdapter<com.mapbox.geojson.Geometry?>): TypeAdapter<Geometry?> {
+    private fun geometryTypeAdapter(writeAdapter: TypeAdapter<com.mapbox.geojson.Geometry?>): TypeAdapter<Geometry?> {
         return object : TypeAdapter<Geometry?>() {
             @Throws(IOException::class)
             override fun write(`out`: JsonWriter, value: Geometry?) {
                 value?.let { geometry ->
                     GeometryConverter.convert(geometry)?.let {
-                        typeAdapter.write(`out`, it)
+                        writeAdapter.write(`out`, it)
                     }
                 }
             }
 
             @Throws(IOException::class)
             override fun read(`in`: JsonReader): Geometry? {
-                val geometry = typeAdapter.read(`in`) ?: return null
-                return GeometryConverter.convert(geometry)
+                val jsonElement = JsonParser.parseReader(`in`)
+                if (jsonElement == null || jsonElement.isJsonNull) return null
+                val obj = runCatching { jsonElement.asJsonObject }.getOrNull() ?: return null
+                val type = obj.get("type")?.asString ?: return null
+                val json = jsonElement.toString()
+                // Use Mapbox's own fromJson() which correctly handles coordinate arrays
+                // (e.g. [lng,lat] within Polygon rings) rather than the Gson adapter chain,
+                // which falls back to reflection and expects JSON objects for Point coordinates.
+                val mapboxGeometry: com.mapbox.geojson.Geometry? = when (type) {
+                    "Point" -> com.mapbox.geojson.Point.fromJson(json)
+                    "MultiPoint" -> com.mapbox.geojson.MultiPoint.fromJson(json)
+                    "LineString" -> com.mapbox.geojson.LineString.fromJson(json)
+                    "MultiLineString" -> com.mapbox.geojson.MultiLineString.fromJson(json)
+                    "Polygon" -> com.mapbox.geojson.Polygon.fromJson(json)
+                    "MultiPolygon" -> com.mapbox.geojson.MultiPolygon.fromJson(json)
+                    "GeometryCollection" -> com.mapbox.geojson.GeometryCollection.fromJson(json)
+                    else -> null
+                }
+                return mapboxGeometry?.let { GeometryConverter.convert(it) }
             }
         }
     }

--- a/mage/src/main/java/mil/nga/giat/mage/newsfeed/ObservationFeedFragment.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/newsfeed/ObservationFeedFragment.kt
@@ -42,6 +42,7 @@ import mil.nga.giat.mage.database.model.observation.Observation
 import mil.nga.giat.mage.data.datasource.user.UserLocalDataSource
 import mil.nga.giat.mage.utils.googleMapsUri
 import javax.inject.Inject
+import androidx.lifecycle.lifecycleScope
 
 @AndroidEntryPoint
 class ObservationFeedFragment : Fragment() {
@@ -151,7 +152,7 @@ class ObservationFeedFragment : Fragment() {
                override fun onObservationLocation(observation: Observation) {
                   observationLocation(observation)
                }
-            })
+            }, viewLifecycleOwner.lifecycleScope)
 
          landingViewModel.setFilterText(feedState.filterText)
 

--- a/mage/src/main/java/mil/nga/giat/mage/newsfeed/ObservationListAdapter.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/newsfeed/ObservationListAdapter.kt
@@ -3,7 +3,6 @@ package mil.nga.giat.mage.newsfeed
 import android.content.Context
 import android.database.Cursor
 import android.graphics.PorterDuff
-import android.os.AsyncTask
 import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
@@ -34,9 +33,13 @@ import mil.nga.giat.mage.sdk.exceptions.ObservationException
 import mil.nga.giat.mage.sdk.exceptions.UserException
 import mil.nga.giat.mage.utils.DateFormatFactory
 import mil.nga.sf.Point
-import java.lang.ref.WeakReference
 import java.sql.SQLException
 import java.util.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class ObservationListAdapter(
    private val context: Context,
@@ -45,7 +48,8 @@ class ObservationListAdapter(
    private val observationLocalDataSource: ObservationLocalDataSource,
    observationFeedState: ObservationFeedViewModel.ObservationFeedState,
    private val attachmentGallery: AttachmentGallery,
-   private val observationActionListener: ObservationActionListener?
+   private val observationActionListener: ObservationActionListener?,
+   private val scope: CoroutineScope
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
    interface ObservationActionListener {
@@ -81,9 +85,7 @@ class ObservationListAdapter(
 
       var timestamp: Date? = null
       var centroid: Point? = null
-      var userTask: UserTask? = null
-      var primaryPropertyTask: PropertyTask? = null
-      var secondaryPropertyTask: PropertyTask? = null
+      var bindJob: Job? = null
 
       fun bind(observation: Observation) {
          timestamp = observation.timestamp
@@ -161,17 +163,10 @@ class ObservationListAdapter(
 
    override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
       if (holder is ObservationViewHolder) {
-         if (holder.userTask != null) {
-            holder.userTask?.cancel(false)
-         }
-         if (holder.primaryPropertyTask != null) {
-            holder.primaryPropertyTask?.cancel(false)
-         }
-         if (holder.secondaryPropertyTask != null) {
-            holder.secondaryPropertyTask?.cancel(false)
-         }
+          holder.bindJob?.cancel()
       }
    }
+
 
    private fun bindObservation(holder: RecyclerView.ViewHolder, position: Int) {
       cursor.moveToPosition(position)
@@ -208,19 +203,56 @@ class ObservationListAdapter(
             .into(vh.markerView)
 
          vh.primaryView.text = ""
-         vh.primaryPropertyTask = PropertyTask(eventLocalDataSource, PropertyTask.Type.PRIMARY, vh.primaryView)
-         vh.primaryPropertyTask?.execute(observation)
-
          vh.secondaryView.text = ""
-         vh.secondaryPropertyTask = PropertyTask(eventLocalDataSource, PropertyTask.Type.SECONDARY, vh.secondaryView)
-         vh.secondaryPropertyTask?.execute(observation)
+         vh.userView.text = "" 
 
-         vh.userView.text = ""
-         vh.userTask = UserTask(vh.userView)
-         vh.userTask?.execute(observation)
+         // Cancel any in-flight load from a previous binding of this ViewHolder
+         vh.bindJob?.cancel()
+         vh.bindJob = scope.launch {
+               // Fetch user name from local DB on the IO thread
+               val user = withContext(Dispatchers.IO) {
+                  try { userLocalDataSource.read(observation.userId) } catch (e: Exception) { null }
+               }   
+               
+               // Load the form definition once — primary and secondary fields both need it
+               val observationForm = observation.forms.firstOrNull()
+               val form = observationForm?.let {
+                  withContext(Dispatchers.IO) { eventLocalDataSource.getForm(it.formId) }
+               }   
+               
+               // Property look-ups are in-memory once the form is loaded
+               val primaryProperty = observationForm?.properties?.find { it.key == form?.primaryFeedField }
+               val secondaryProperty = observationForm?.properties?.find { it.key == form?.secondaryFeedField }
+               
+               val importantUserName = withContext(Dispatchers.IO) {
+                  try {
+                     observation.important?.userId?.let { userLocalDataSource.read(it)?.displayName }
+                  } catch (e: Exception) { null }
+               }
+
+               // Everything below runs back on the main thread (scope is Main)
+               vh.userView.text = user?.displayName ?: "Unknown User"
+
+               if (primaryProperty == null || primaryProperty.isEmpty) {
+                  vh.primaryView.visibility = View.GONE
+               } else {
+                  vh.primaryView.text = primaryProperty.value.toString()
+                  vh.primaryView.visibility = View.VISIBLE
+               }
+               vh.primaryView.requestLayout()
+
+               if (secondaryProperty == null || secondaryProperty.isEmpty) {
+                  vh.secondaryView.visibility = View.GONE
+               } else {
+                  vh.secondaryView.text = secondaryProperty.value.toString()
+                  vh.secondaryView.visibility = View.VISIBLE
+               }
+               vh.secondaryView.requestLayout()
+
+               setImportantView(observation.important, importantUserName, vh)
+         }
 
          updateTimeZoneDisplay(vh)
-         setImportantView(observation.important, vh)
 
          val error = observation.error
          if (error != null) {
@@ -259,18 +291,11 @@ class ObservationListAdapter(
       vh.footerText.text = footerText
    }
 
-   private fun setImportantView(important: ObservationImportant?, vh: ObservationViewHolder) {
+   private fun setImportantView(important: ObservationImportant?, flaggedByName: String?, vh: ObservationViewHolder) {
       val isImportant = important != null && important.isImportant
       vh.importantView.visibility = if (isImportant) View.VISIBLE else View.GONE
       if (isImportant) {
-         try {
-            important?.userId?.let {
-               val user = userLocalDataSource.read(it)
-               vh.importantOverline.text = String.format("FLAGGED BY %s", user?.displayName?.uppercase(Locale.getDefault()))
-            }
-         } catch (e: UserException) {
-            Log.e(LOG_NAME, "Error reading important user", e)
-         }
+         vh.importantOverline.text = String.format("FLAGGED BY %s", flaggedByName?.uppercase(Locale.getDefault()) ?: "UNKNOWN")
          vh.importantDescription.text = important!!.description
       }
    }
@@ -324,62 +349,6 @@ class ObservationListAdapter(
 
    private fun onLocationClick(observation: Observation) {
       observationActionListener?.onObservationLocation(observation)
-   }
-
-   internal inner class UserTask(textView: TextView) : AsyncTask<Observation?, Void?, User?>() {
-      private val reference: WeakReference<TextView> = WeakReference(textView)
-
-      override fun doInBackground(vararg observations: Observation?): User? {
-         return try {
-            observations.firstOrNull()?.userId?.let { userId ->
-               userLocalDataSource.read(userId)
-            }
-         } catch (e: Exception) { null }
-      }
-
-      override fun onPostExecute(u: User?) {
-         val user = if (isCancelled) null else u
-
-         val textView = reference.get()
-         if (textView != null) {
-            if (user != null) {
-               textView.text = user.displayName
-            } else {
-               textView.text = "Unknown User"
-            }
-         }
-      }
-   }
-
-   private class PropertyTask(private val eventLocalDataSource: EventLocalDataSource, private val type: Type, textView: TextView) : AsyncTask<Observation?, Void?, ObservationProperty>() {
-      enum class Type { PRIMARY, SECONDARY }
-
-      private val reference: WeakReference<TextView> = WeakReference(textView)
-
-      override fun doInBackground(vararg observations: Observation?): ObservationProperty? {
-         val field = observations[0]?.forms?.firstOrNull()?.let { observationForm ->
-            val form = eventLocalDataSource.getForm(observationForm.formId)
-            val fieldName = if (type == Type.PRIMARY) form?.primaryFeedField else form?.secondaryFeedField
-            observationForm.properties.find { it.key == fieldName }
-         }
-
-         return field
-      }
-
-      override fun onPostExecute(p: ObservationProperty?) {
-         val property = if (isCancelled) null else p
-
-         val textView = reference.get()
-         if (textView != null) {
-            if (property == null || property.isEmpty) {
-               textView.visibility = View.GONE
-            } else {
-               textView.text = property.value.toString()
-               textView.visibility = View.VISIBLE
-            }
-            textView.requestLayout()
-         }
-      }
    }
 
    companion object {

--- a/mage/src/main/java/mil/nga/giat/mage/observation/attachment/AttachmentViewScreen.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/observation/attachment/AttachmentViewScreen.kt
@@ -20,10 +20,11 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.swiperefreshlayout.widget.CircularProgressDrawable
-import com.google.accompanist.glide.rememberGlidePainter
-import com.google.android.exoplayer2.ExoPlayer
-import com.google.android.exoplayer2.MediaItem
-import com.google.android.exoplayer2.ui.StyledPlayerView
+import com.bumptech.glide.integration.compose.ExperimentalGlideComposeApi
+import com.bumptech.glide.integration.compose.GlideImage
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.common.MediaItem
+import androidx.media3.ui.PlayerView
 import mil.nga.giat.mage.ui.theme.MageTheme
 import mil.nga.giat.mage.ui.theme.topAppBarBackground
 
@@ -158,17 +159,12 @@ private fun AttachmentImageContent(state: AttachmentState.ImageState) {
          .fillMaxWidth()
          .background(Color(0x19000000))
    ) {
-      Image(
-         painter = rememberGlidePainter(
-            state.model,
-            fadeIn = true,
-            requestBuilder = {
-               placeholder(progress)
-            }
-         ),
+      @OptIn(ExperimentalGlideComposeApi::class)
+      GlideImage(
+         model = state.model,
          contentDescription = "Image",
-         Modifier.fillMaxSize()
-      )
+         modifier = Modifier.fillMaxSize(),
+      ) { it.placeholder(progress) }
    }
 }
 
@@ -191,8 +187,8 @@ private fun AttachmentMediaContent(
       }
 
       AndroidView(factory = { context ->
-         StyledPlayerView(context).apply {
-            setShowBuffering(StyledPlayerView.SHOW_BUFFERING_ALWAYS)
+         PlayerView(context).apply {
+            setShowBuffering(PlayerView.SHOW_BUFFERING_ALWAYS)
             player = exoPlayer
          }
       })

--- a/mage/src/main/java/mil/nga/giat/mage/observation/edit/ObservationEditScreen.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/observation/edit/ObservationEditScreen.kt
@@ -6,7 +6,10 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.*
+import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.*
 import androidx.compose.material.*
@@ -17,13 +20,17 @@ import androidx.compose.material.icons.outlined.Redo
 import androidx.compose.material.icons.outlined.Undo
 import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import kotlinx.android.parcel.Parcelize
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import mil.nga.giat.mage.compat.server5.form.view.AttachmentsViewContentServer5
 import mil.nga.giat.mage.database.model.event.Event
@@ -109,13 +116,31 @@ fun ObservationEditScreen(
         )
       },
       content = {
-        Box(modifier = Modifier.fillMaxSize()) {
-          Column(modifier = Modifier.fillMaxSize().imePadding()) {
-            if (isServerVersion5(LocalContext.current)) {
-              ObservationMediaBar { onMediaAction?.invoke(MediaAction(it, null, null)) }
+        var lastFocusedField by remember { mutableStateOf<FieldState<*, *>?>(null) }
+        focusedUndoField?.let { lastFocusedField = it }
+
+        var undoBarHeightPx by remember { mutableStateOf(0) }
+        val density = LocalDensity.current
+
+        // Scroll the list up by the bar height when it first appears so the focused
+        // field is not hidden behind it.
+        LaunchedEffect(Unit) {
+          snapshotFlow { (focusedUndoField != null) to undoBarHeightPx }
+            .distinctUntilChanged()
+            .collect { (focused, height) ->
+              if (focused && height > 0) {
+                listState.animateScrollBy(height.toFloat())
+              }
             }
+        }
+
+        Column(modifier = Modifier.fillMaxSize().imePadding()) {
+          if (isServerVersion5(LocalContext.current)) {
+            ObservationMediaBar { onMediaAction?.invoke(MediaAction(it, null, null)) }
+          }
 
           ObservationEditContent(
+            modifier = Modifier.weight(1f),
             event = viewModel.event,
             observationState = observationState,
             listState = listState,
@@ -158,20 +183,16 @@ fun ObservationEditScreen(
               onDeleteForm?.invoke(index)
             }
           )
-        }
-
-          var lastFocusedField by remember { mutableStateOf<FieldState<*, *>?>(null) }
-          focusedUndoField?.let { lastFocusedField = it }
 
           AnimatedVisibility(
             visible = focusedUndoField != null,
-            enter = fadeIn(animationSpec = tween(200)),
-            exit = fadeOut(animationSpec = tween(200)),
-            modifier = Modifier
-              .align(Alignment.BottomCenter)
-              .imePadding()
+            enter = slideInVertically { it } + fadeIn(animationSpec = tween(200)),
+            exit = slideOutVertically { it } + fadeOut(animationSpec = tween(200)),
           ) {
-            UndoRedoBar(focusedField = lastFocusedField)
+            UndoRedoBar(
+              focusedField = lastFocusedField,
+              modifier = Modifier.onSizeChanged { undoBarHeightPx = it.height }
+            )
           }
         }
       },
@@ -256,6 +277,7 @@ fun ObservationMediaBar(
 
 @Composable
 fun ObservationEditContent(
+  modifier: Modifier = Modifier,
   event: Event?,
   observationState: ObservationState?,
   listState: LazyListState,
@@ -267,6 +289,7 @@ fun ObservationEditContent(
 ) {
   val context = LocalContext.current
 
+  Box(modifier = modifier) {
   if (observationState != null) {
     val forms by observationState.forms
     var previousForms by remember { mutableStateOf<List<FormState>>(listOf()) }
@@ -293,7 +316,7 @@ fun ObservationEditContent(
       verticalArrangement = Arrangement.spacedBy(8.dp),
       modifier = Modifier
         .background(Color(0x19000000))
-        .fillMaxHeight()
+        .fillMaxSize()
         .windowInsetsPadding(WindowInsets.systemBars.union(WindowInsets.displayCutout).only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom))
 
     ) {
@@ -362,6 +385,7 @@ fun ObservationEditContent(
       }
     }
   }
+  } // Box
 }
 
 @Composable

--- a/mage/src/main/java/mil/nga/giat/mage/observation/edit/ObservationEditScreen.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/observation/edit/ObservationEditScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.material.*
 import androidx.compose.material.ButtonDefaults.textButtonColors
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.outlined.Redo
+import androidx.compose.material.icons.outlined.Undo
 import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
@@ -67,6 +69,20 @@ fun ObservationEditScreen(
   val scaffoldState = rememberScaffoldState()
   val listState = rememberLazyListState()
 
+  val focusedUndoField by remember {
+    derivedStateOf {
+      observationState?.forms?.value
+        ?.flatMap { it.fields }
+        ?.firstOrNull { field ->
+          field.isFocused && when (field) {
+            is TextFieldState -> field.canUndo || field.canRedo
+            is NumberFieldState -> field.canUndo || field.canRedo
+            else -> false
+          }
+        }
+    }
+  }
+
   MageTheme {
     Scaffold(
       scaffoldState = scaffoldState,
@@ -89,10 +105,11 @@ fun ObservationEditScreen(
         )
       },
       content = {
-        Column(modifier = Modifier.fillMaxSize().imePadding())  {
-          if (isServerVersion5(LocalContext.current)) {
-            ObservationMediaBar { onMediaAction?.invoke(MediaAction(it, null, null)) }
-          }
+        Box(modifier = Modifier.fillMaxSize()) {
+          Column(modifier = Modifier.fillMaxSize().imePadding()) {
+            if (isServerVersion5(LocalContext.current)) {
+              ObservationMediaBar { onMediaAction?.invoke(MediaAction(it, null, null)) }
+            }
 
           ObservationEditContent(
             event = viewModel.event,
@@ -136,6 +153,14 @@ fun ObservationEditScreen(
               }
               onDeleteForm?.invoke(index)
             }
+          )
+        }
+
+          UndoRedoBar(
+            modifier = Modifier
+              .align(Alignment.BottomCenter)
+              .imePadding(),
+            focusedField = focusedUndoField
           )
         }
       },
@@ -354,6 +379,61 @@ fun ObservationEditHeaderContent(
         onClick = onLocationClick,
         modifier = Modifier.padding(bottom = 16.dp)
       )
+    }
+  }
+}
+
+@Composable
+fun UndoRedoBar(
+  modifier: Modifier = Modifier,
+  focusedField: FieldState<*, *>?
+) {
+  val canUndo = when (focusedField) {
+    is TextFieldState -> focusedField.canUndo
+    is NumberFieldState -> focusedField.canUndo
+    else -> false
+  }
+  val canRedo = when (focusedField) {
+    is TextFieldState -> focusedField.canRedo
+    is NumberFieldState -> focusedField.canRedo
+    else -> false
+  }
+
+  if (!canUndo && !canRedo) return
+
+  Surface(
+    modifier = modifier.fillMaxWidth(),
+    elevation = 8.dp,
+    color = MaterialTheme.colors.surface
+  ) {
+    Row(
+      modifier = Modifier.padding(horizontal = 8.dp, vertical = 2.dp),
+      verticalAlignment = Alignment.CenterVertically
+    ) {
+      IconButton(onClick = {
+        when (focusedField) {
+          is TextFieldState -> focusedField.undo()
+          is NumberFieldState -> focusedField.undo()
+          else -> {}
+        }
+      }, enabled = canUndo) {
+        Icon(
+          imageVector = Icons.Outlined.Undo,
+          contentDescription = "Undo"
+        )
+      }
+      IconButton(onClick = {
+        when (focusedField) {
+          is TextFieldState -> focusedField.redo()
+          is NumberFieldState -> focusedField.redo()
+          else -> {}
+        }
+      }, enabled = canRedo) {
+        Icon(
+          imageVector = Icons.Outlined.Redo,
+          contentDescription = "Redo"
+        )
+      }
     }
   }
 }

--- a/mage/src/main/java/mil/nga/giat/mage/observation/edit/ObservationEditScreen.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/observation/edit/ObservationEditScreen.kt
@@ -2,6 +2,10 @@ package mil.nga.giat.mage.observation.edit
 
 import android.annotation.SuppressLint
 import android.os.Parcelable
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.*
@@ -75,8 +79,8 @@ fun ObservationEditScreen(
         ?.flatMap { it.fields }
         ?.firstOrNull { field ->
           field.isFocused && when (field) {
-            is TextFieldState -> field.canUndo || field.canRedo
-            is NumberFieldState -> field.canUndo || field.canRedo
+            is TextFieldState -> field.isTypingActive && (field.canUndo || field.canRedo)
+            is NumberFieldState -> field.isTypingActive && (field.canUndo || field.canRedo)
             else -> false
           }
         }
@@ -156,12 +160,19 @@ fun ObservationEditScreen(
           )
         }
 
-          UndoRedoBar(
+          var lastFocusedField by remember { mutableStateOf<FieldState<*, *>?>(null) }
+          focusedUndoField?.let { lastFocusedField = it }
+
+          AnimatedVisibility(
+            visible = focusedUndoField != null,
+            enter = fadeIn(animationSpec = tween(200)),
+            exit = fadeOut(animationSpec = tween(200)),
             modifier = Modifier
               .align(Alignment.BottomCenter)
-              .imePadding(),
-            focusedField = focusedUndoField
-          )
+              .imePadding()
+          ) {
+            UndoRedoBar(focusedField = lastFocusedField)
+          }
         }
       },
       floatingActionButton = {
@@ -398,8 +409,6 @@ fun UndoRedoBar(
     is NumberFieldState -> focusedField.canRedo
     else -> false
   }
-
-  if (!canUndo && !canRedo) return
 
   Surface(
     modifier = modifier.fillMaxWidth(),

--- a/mage/src/main/java/mil/nga/giat/mage/ui/map/MapSearch.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/ui/map/MapSearch.kt
@@ -43,8 +43,8 @@ import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapType
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.Marker
-import com.google.maps.android.compose.MarkerState
 import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.maps.android.compose.rememberMarkerState
 import mil.nga.giat.mage.R
 import mil.nga.giat.mage.search.GeocoderResult
 import mil.nga.giat.mage.ui.search.PlacenameSearch
@@ -168,7 +168,7 @@ private fun Map(
    ) {
       searchResult?.let {
          Marker(
-            state = MarkerState(position = it.location),
+            state = rememberMarkerState(position = it.location),
             title = it.name,
             snippet = it.address,
             icon = BitmapDescriptorFactory.defaultMarker(211f)

--- a/mage/src/main/java/mil/nga/giat/mage/ui/theme/Theme.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/ui/theme/Theme.kt
@@ -13,11 +13,11 @@ private val LightColorPalette = lightColors(
 )
 
 private val DarkColorPalette = darkColors(
-  primary = Grey900,
-  primaryVariant = Grey900,
+  primary = Color.White,
+  primaryVariant = Grey800,
   secondary = BlueA200,
   error = Red300,
-  onPrimary = Color.White
+  onPrimary = Color(0xFF121212)
 )
 
 @Composable
@@ -34,7 +34,7 @@ fun MageTheme(
 }
 
 val Colors.warning: Color @Composable get() = Amber700
-val Colors.topAppBarBackground: Color @Composable get() = primary
+val Colors.topAppBarBackground: Color @Composable get() = if (isSystemInDarkTheme()) Grey900 else primary
 val Colors.importantBackground: Color @Composable get() = OrangeA400
 val Colors.linkColor: Color @Composable get() {
  return if (isSystemInDarkTheme()) MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium) else primary

--- a/mage/src/main/java/mil/nga/giat/mage/ui/theme/Theme3.kt
+++ b/mage/src/main/java/mil/nga/giat/mage/ui/theme/Theme3.kt
@@ -17,11 +17,11 @@ private val LightColorPalette = lightColorScheme(
 )
 
 private val DarkColorPalette = darkColorScheme(
-  primary = Grey900,
+  primary = Color.White,
   secondary = BlueA200,
   tertiary = Color(0xDDFFFFFF),
   error = Red300,
-  onPrimary = Color.White,
+  onPrimary = Color(0xFF121212),
   surfaceVariant = Color(red = 42, green = 41, blue = 45)
 )
 

--- a/mage/src/main/res/xml/network_security_config.xml
+++ b/mage/src/main/res/xml/network_security_config.xml
@@ -6,4 +6,8 @@
             <certificates src="system"/>
         </trust-anchors>
     </base-config>
+    <!-- Allow cleartext HTTP to the Android emulator host address so local Docker dev works -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+    </domain-config>
 </network-security-config>

--- a/mage/src/test/java/mil/nga/giat/mage/form/field/NumberFieldStateTest.kt
+++ b/mage/src/test/java/mil/nga/giat/mage/form/field/NumberFieldStateTest.kt
@@ -1,0 +1,164 @@
+package mil.nga.giat.mage.form.field
+
+import mil.nga.giat.mage.form.FieldType
+import mil.nga.giat.mage.form.NumberFormField
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class NumberFieldStateTest {
+
+    private lateinit var state: NumberFieldState
+
+    @Before
+    fun setUp() {
+        state = NumberFieldState(
+            NumberFormField(id = 1, type = FieldType.NUMBERFIELD, name = "field", title = "Field", required = false, archived = false, min = null, max = null)
+        )
+    }
+
+    @Test
+    fun `canUndo is false initially`() {
+        assertFalse(state.canUndo)
+    }
+
+    @Test
+    fun `canRedo is false initially`() {
+        assertFalse(state.canRedo)
+    }
+
+    @Test
+    fun `answer is null initially`() {
+        assertNull(state.answer)
+    }
+
+    @Test
+    fun `pushHistory enables canUndo`() {
+        state.pushHistory("1")
+        assertTrue(state.canUndo)
+    }
+
+    @Test
+    fun `pushHistory clears redo stack`() {
+        state.answer = FieldValue.Number("1")
+        state.pushHistory("1")
+        state.answer = FieldValue.Number("12")
+        state.undo()
+        assertTrue(state.canRedo)
+
+        state.pushHistory("1")
+        assertFalse(state.canRedo)
+    }
+
+    @Test
+    fun `undo restores previous value`() {
+        state.answer = FieldValue.Number("42")
+        state.pushHistory("42")
+        state.answer = FieldValue.Number("420")
+
+        state.undo()
+
+        assertEquals("42", state.answer?.number)
+    }
+
+    @Test
+    fun `undo enables canRedo`() {
+        state.answer = FieldValue.Number("1")
+        state.pushHistory("1")
+        state.answer = FieldValue.Number("12")
+
+        state.undo()
+
+        assertTrue(state.canRedo)
+    }
+
+    @Test
+    fun `canUndo is false after undoing all history`() {
+        state.answer = FieldValue.Number("1")
+        state.pushHistory("1")
+        state.answer = FieldValue.Number("12")
+
+        state.undo()
+
+        assertFalse(state.canUndo)
+    }
+
+    @Test
+    fun `undo does nothing when stack is empty`() {
+        state.answer = FieldValue.Number("99")
+        state.undo()
+        assertEquals("99", state.answer?.number)
+    }
+
+    @Test
+    fun `undo supports multiple steps`() {
+        state.answer = FieldValue.Number("1")
+        state.pushHistory("1")
+        state.answer = FieldValue.Number("12")
+        state.pushHistory("12")
+        state.answer = FieldValue.Number("123")
+
+        state.undo()
+        assertEquals("12", state.answer?.number)
+
+        state.undo()
+        assertEquals("1", state.answer?.number)
+    }
+
+    @Test
+    fun `redo restores undone value`() {
+        state.answer = FieldValue.Number("42")
+        state.pushHistory("42")
+        state.answer = FieldValue.Number("420")
+
+        state.undo()
+        state.redo()
+
+        assertEquals("420", state.answer?.number)
+    }
+
+    @Test
+    fun `canRedo is false after redoing all`() {
+        state.answer = FieldValue.Number("1")
+        state.pushHistory("1")
+        state.answer = FieldValue.Number("12")
+
+        state.undo()
+        state.redo()
+
+        assertFalse(state.canRedo)
+    }
+
+    @Test
+    fun `redo does nothing when stack is empty`() {
+        state.answer = FieldValue.Number("99")
+        state.redo()
+        assertEquals("99", state.answer?.number)
+    }
+
+    @Test
+    fun `two number fields maintain independent histories`() {
+        val state2 = NumberFieldState(
+            NumberFormField(id = 2, type = FieldType.NUMBERFIELD, name = "other", title = "Other", required = false, archived = false, min = null, max = null)
+        )
+
+        state.answer = FieldValue.Number("1")
+        state.pushHistory("1")
+        state.answer = FieldValue.Number("12")
+
+        state2.answer = FieldValue.Number("9")
+        state2.pushHistory("9")
+        state2.answer = FieldValue.Number("99")
+
+        state.undo()
+        assertEquals("1", state.answer?.number)
+        assertEquals("99", state2.answer?.number)
+
+        state2.undo()
+        assertEquals("1", state.answer?.number)
+        assertEquals("9", state2.answer?.number)
+    }
+}

--- a/mage/src/test/java/mil/nga/giat/mage/form/field/TextFieldStateTest.kt
+++ b/mage/src/test/java/mil/nga/giat/mage/form/field/TextFieldStateTest.kt
@@ -1,0 +1,176 @@
+package mil.nga.giat.mage.form.field
+
+import mil.nga.giat.mage.form.FieldType
+import mil.nga.giat.mage.form.TextFormField
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class TextFieldStateTest {
+
+    private lateinit var state: TextFieldState
+
+    @Before
+    fun setUp() {
+        state = TextFieldState(
+            TextFormField(id = 1, type = FieldType.TEXTFIELD, name = "field", title = "Field", required = false, archived = false)
+        )
+    }
+
+    @Test
+    fun `canUndo is false initially`() {
+        assertFalse(state.canUndo)
+    }
+
+    @Test
+    fun `canRedo is false initially`() {
+        assertFalse(state.canRedo)
+    }
+
+    @Test
+    fun `answer is null initially`() {
+        assertNull(state.answer)
+    }
+
+    @Test
+    fun `pushHistory enables canUndo`() {
+        state.pushHistory("hello")
+        assertTrue(state.canUndo)
+    }
+
+    @Test
+    fun `pushHistory clears redo stack`() {
+        state.answer = FieldValue.Text("a")
+        state.pushHistory("a")
+        state.answer = FieldValue.Text("ab")
+        state.undo()
+        assertTrue(state.canRedo)
+
+        state.pushHistory("a")
+        assertFalse(state.canRedo)
+    }
+
+    @Test
+    fun `undo restores previous value`() {
+        state.answer = FieldValue.Text("hello")
+        state.pushHistory("hello")
+        state.answer = FieldValue.Text("hello world")
+
+        state.undo()
+
+        assertEquals("hello", state.answer?.text)
+    }
+
+    @Test
+    fun `undo enables canRedo`() {
+        state.answer = FieldValue.Text("a")
+        state.pushHistory("a")
+        state.answer = FieldValue.Text("ab")
+
+        state.undo()
+
+        assertTrue(state.canRedo)
+    }
+
+    @Test
+    fun `canUndo is false after undoing all history`() {
+        state.answer = FieldValue.Text("a")
+        state.pushHistory("a")
+        state.answer = FieldValue.Text("ab")
+
+        state.undo()
+
+        assertFalse(state.canUndo)
+    }
+
+    @Test
+    fun `undo does nothing when stack is empty`() {
+        state.answer = FieldValue.Text("hello")
+        state.undo()
+        assertEquals("hello", state.answer?.text)
+    }
+
+    @Test
+    fun `undo supports multiple steps`() {
+        state.answer = FieldValue.Text("a")
+        state.pushHistory("a")
+        state.answer = FieldValue.Text("ab")
+        state.pushHistory("ab")
+        state.answer = FieldValue.Text("abc")
+
+        state.undo()
+        assertEquals("ab", state.answer?.text)
+
+        state.undo()
+        assertEquals("a", state.answer?.text)
+    }
+
+    @Test
+    fun `redo restores undone value`() {
+        state.answer = FieldValue.Text("hello")
+        state.pushHistory("hello")
+        state.answer = FieldValue.Text("hello world")
+
+        state.undo()
+        state.redo()
+
+        assertEquals("hello world", state.answer?.text)
+    }
+
+    @Test
+    fun `canRedo is false after redoing all`() {
+        state.answer = FieldValue.Text("a")
+        state.pushHistory("a")
+        state.answer = FieldValue.Text("ab")
+
+        state.undo()
+        state.redo()
+
+        assertFalse(state.canRedo)
+    }
+
+    @Test
+    fun `redo re-enables canUndo`() {
+        state.answer = FieldValue.Text("a")
+        state.pushHistory("a")
+        state.answer = FieldValue.Text("ab")
+
+        state.undo()
+        state.redo()
+
+        assertTrue(state.canUndo)
+    }
+
+    @Test
+    fun `redo does nothing when stack is empty`() {
+        state.answer = FieldValue.Text("hello")
+        state.redo()
+        assertEquals("hello", state.answer?.text)
+    }
+
+    @Test
+    fun `two fields maintain independent histories`() {
+        val state2 = TextFieldState(
+            TextFormField(id = 2, type = FieldType.TEXTFIELD, name = "other", title = "Other", required = false, archived = false)
+        )
+
+        state.answer = FieldValue.Text("a")
+        state.pushHistory("a")
+        state.answer = FieldValue.Text("ab")
+
+        state2.answer = FieldValue.Text("x")
+        state2.pushHistory("x")
+        state2.answer = FieldValue.Text("xy")
+
+        state.undo()
+        assertEquals("a", state.answer?.text)
+        assertEquals("xy", state2.answer?.text)
+
+        state2.undo()
+        assertEquals("a", state.answer?.text)
+        assertEquals("x", state2.answer?.text)
+    }
+}


### PR DESCRIPTION
- Added undo/redo functionality as well as UI buttons over keyboard to mimic iOS updates
- Upgraded M3 and Compose to 1.4.3 & 1.8.0 respectively to gain access to 'TextFieldState.undoState'
- `material-icons-core` and `material-icons-extended` are pinned at `1.7.8` because those two artifacts were not published at version `1.8.0` by Google; all other Compose artifacts are at `1.8.0`.