### PR TITLE
Obscure DEBUG_MAPS_API_KEY in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ android.r8.strictFullModeForKeepRules=false
 android.r8.optimizedResourceShrinking=false
 android.builtInKotlin=false
 android.newDsl=false
-DEBUG_MAPS_API_KEY=AIzaSyAAFhmzxYOgltoCQKXAd93XZPxc5zRqfT8
+DEBUG_MAPS_API_KEY=...


### PR DESCRIPTION
Obscured the API key for security reasons.